### PR TITLE
Make slave jar the first argument to java command when building docke…

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/nomad/NomadApi.java
+++ b/src/main/java/org/jenkinsci/plugins/nomad/NomadApi.java
@@ -33,7 +33,7 @@ public final class NomadApi {
             jnlpSecret,
             template
         );
-
+        LOGGER.log(Level.INFO, slaveJob);
         try {
             RequestBody body = RequestBody.create(JSON, slaveJob);
             Request request = new Request.Builder()
@@ -107,7 +107,7 @@ public final class NomadApi {
                 ),
                 new LogConfig(1, 10),
                 new Artifact[]{
-                    new Artifact(template.getCloud().getSlaveUrl(), null, "local/")
+                    new Artifact(template.getCloud().getSlaveUrl(), null, "")
                 }
         );
 

--- a/src/main/java/org/jenkinsci/plugins/nomad/NomadApi.java
+++ b/src/main/java/org/jenkinsci/plugins/nomad/NomadApi.java
@@ -79,8 +79,8 @@ public final class NomadApi {
             driverConfig.put("jar_path", "/local/slave.jar");
             driverConfig.put("args", args);
         } else if (template.getDriver().equals("docker")) {
-            args.add("-jar");
-            args.add("/local/slave.jar");
+            args.add(0, "-jar");
+            args.add(1, "/local/slave.jar");
 
             driverConfig.put("image", template.getImage());
             driverConfig.put("command", "java");

--- a/src/test/java/org/jenkinsci/plugins/nomad/NomadApiTest.java
+++ b/src/test/java/org/jenkinsci/plugins/nomad/NomadApiTest.java
@@ -15,7 +15,7 @@ public class NomadApiTest {
     NomadSlaveTemplate slaveTemplate = new NomadSlaveTemplate(
             "300", "256", "100",
             null, "remoteFs", "3",
-            "ams", "0", "image"
+            "ams", "0", "image", "dc01"
     );
 
     private NomadCloud nomadCloud = new NomadCloud(


### PR DESCRIPTION
…r driver. Otherwise the jnlpUrl get rejected

At least I am getting "java: Unrecognized option: -jnlpUrl" on a centos7 slave image with java8.
Putting -jar /local/slave.jar as the first argument fixes this.

 
