### PR TITLE
Allow restricting node usage to jobs with label restriction

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/nomad/NomadCloud.java
+++ b/src/main/java/org/jenkinsci/plugins/nomad/NomadCloud.java
@@ -122,7 +122,6 @@ public class NomadCloud extends AbstractCloudImpl {
                     "Nomad Jenkins Slave",
                     template,
                     template.getLabels(),
-                    Node.Mode.NORMAL,
                     new NomadRetentionStrategy(template.getIdleTerminationInMinutes()),
                     Collections.<NodeProperty<?>>emptyList()
             );

--- a/src/main/java/org/jenkinsci/plugins/nomad/NomadSlave.java
+++ b/src/main/java/org/jenkinsci/plugins/nomad/NomadSlave.java
@@ -23,7 +23,6 @@ public class NomadSlave extends AbstractCloudSlave implements EphemeralNode {
         String nodeDescription,
         NomadSlaveTemplate template,
         String labelString,
-        Mode mode,
         hudson.slaves.RetentionStrategy retentionStrategy,
         List<? extends NodeProperty<?>> nodeProperties
     ) throws Descriptor.FormException, IOException {
@@ -32,7 +31,7 @@ public class NomadSlave extends AbstractCloudSlave implements EphemeralNode {
             nodeDescription,
             template.getRemoteFs(),
             template.getNumExecutors(),
-            mode,
+            template.getMode(),
             labelString,
             new JNLPLauncher(),
             retentionStrategy,

--- a/src/main/java/org/jenkinsci/plugins/nomad/NomadSlaveTemplate.java
+++ b/src/main/java/org/jenkinsci/plugins/nomad/NomadSlaveTemplate.java
@@ -7,6 +7,7 @@ import hudson.Util;
 import hudson.model.Describable;
 import hudson.model.Descriptor;
 import hudson.model.Label;
+import hudson.model.Node;
 import hudson.model.labels.LabelAtom;
 import jenkins.model.Jenkins;
 
@@ -35,6 +36,7 @@ public class NomadSlaveTemplate implements Describable<NomadSlaveTemplate> {
     private final String username;
     private final String password;
     private final String prefixCmd;
+    private final Node.Mode mode;
 
     private NomadCloud cloud;
     private String driver;
@@ -50,6 +52,7 @@ public class NomadSlaveTemplate implements Describable<NomadSlaveTemplate> {
             String remoteFs,
             String idleTerminationInMinutes,
             String numExecutors,
+            Node.Mode mode,
             String region,
             String priority,
             String image,
@@ -66,6 +69,7 @@ public class NomadSlaveTemplate implements Describable<NomadSlaveTemplate> {
         this.priority = Integer.parseInt(priority);
         this.idleTerminationInMinutes = Integer.parseInt(idleTerminationInMinutes);
         this.numExecutors = Integer.parseInt(numExecutors);
+        this.mode = mode;
         this.remoteFs = remoteFs;
         this.labels = Util.fixNull(labels);
         this.labelSet = Label.parse(labels);
@@ -116,6 +120,11 @@ public class NomadSlaveTemplate implements Describable<NomadSlaveTemplate> {
     public int getNumExecutors() {
         return numExecutors;
     }
+    
+    public Node.Mode getMode() {
+        return mode;
+    }
+
 
     public int getCpu() {
         return cpu;

--- a/src/main/resources/org/jenkinsci/plugins/nomad/NomadSlaveTemplate/config.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/nomad/NomadSlaveTemplate/config.jelly
@@ -39,6 +39,8 @@
         <f:entry title="Executors" field="numExecutors">
             <f:textbox default="1" />
         </f:entry>
+        
+        <f:slave-mode name="mode" field="mode" node="${instance}" />
 
         <f:entry title="Workspace root" field="remoteFs">
             <f:textbox/>

--- a/src/test/java/org/jenkinsci/plugins/nomad/NomadApiTest.java
+++ b/src/test/java/org/jenkinsci/plugins/nomad/NomadApiTest.java
@@ -1,5 +1,6 @@
 package org.jenkinsci.plugins.nomad;
 
+import hudson.model.Node;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -14,7 +15,7 @@ public class NomadApiTest {
     private NomadApi nomadApi = new NomadApi("http://localhost");
     private NomadSlaveTemplate slaveTemplate = new NomadSlaveTemplate(
             "300", "256", "100",
-            null, "remoteFs", "3",
+            null, "remoteFs", "3","1", Node.Mode.NORMAL,
             "ams", "0", "image", "dc01", "", "", false, "bridge",""
     );
 


### PR DESCRIPTION
We have a number of jobs which we don't want running on Nomad slaves. 
Instead of editing existing jobs (quite a lot of them) we want to be able restrict this on slave template level.
AFAIK - almost every jenkins cloud implementation already has this, so it's only natural to add this to Nomad.
