### PR TITLE
Start of a fix for Nomad 0.5

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/nomad/Api/EphemeralDisk.java
+++ b/src/main/java/org/jenkinsci/plugins/nomad/Api/EphemeralDisk.java
@@ -1,0 +1,38 @@
+package org.jenkinsci.plugins.nomad.Api;
+
+public class EphemeralDisk {
+
+    private Integer Size;
+    private Boolean Migrate;
+    private Boolean Sticky;
+    
+    public EphemeralDisk(Integer size, Boolean migrate, Boolean sticky) {
+        Size = size;
+        Migrate = migrate;
+        Sticky = sticky;
+    }
+
+    public Integer getSize() {
+        return Size;
+    }
+
+    public void setSize(Integer size) {
+        Size = size;
+    }
+
+    public Boolean getMigrate() {
+        return Migrate;
+    }
+
+    public void setMigrate(Boolean migrate) {
+        Migrate = migrate;
+    }
+    
+    public Boolean getSticky() {
+        return Sticky;
+    }
+
+    public void setSticky(Boolean sticky) {
+        Sticky = sticky;
+    }
+}

--- a/src/main/java/org/jenkinsci/plugins/nomad/Api/Resource.java
+++ b/src/main/java/org/jenkinsci/plugins/nomad/Api/Resource.java
@@ -3,12 +3,10 @@ package org.jenkinsci.plugins.nomad.Api;
 public class Resource {
     private Integer CPU;
     private Integer MemoryMB;
-    private Integer DiskMB;
-
-    public Resource(Integer CPU, Integer memoryMB, Integer diskMB) {
+	
+    public Resource(Integer CPU, Integer memoryMB) {
         this.CPU = CPU;
         MemoryMB = memoryMB;
-        DiskMB = diskMB;
     }
 
     public Integer getCPU() {
@@ -25,13 +23,5 @@ public class Resource {
 
     public void setMemoryMB(Integer memoryMB) {
         MemoryMB = memoryMB;
-    }
-
-    public Integer getDiskMB() {
-        return DiskMB;
-    }
-
-    public void setDiskMB(Integer diskMB) {
-        DiskMB = diskMB;
     }
 }

--- a/src/main/java/org/jenkinsci/plugins/nomad/Api/TaskGroup.java
+++ b/src/main/java/org/jenkinsci/plugins/nomad/Api/TaskGroup.java
@@ -5,13 +5,14 @@ public class TaskGroup {
     private Integer Count;
     private Task[] Tasks;
     private RestartPolicy RestartPolicy;
+    private EphemeralDisk EphemeralDisk;
 
-    public TaskGroup(String name, Integer count, Task[] tasks, RestartPolicy restartPolicy) {
+    public TaskGroup(String name, Integer count, Task[] tasks, RestartPolicy restartPolicy, EphemeralDisk ephemeralDisk) {
         Name = name;
         Count = count;
         Tasks = tasks;
         RestartPolicy = restartPolicy;
-
+        EphemeralDisk = ephemeralDisk;
     }
 
     public String getName() {
@@ -44,5 +45,13 @@ public class TaskGroup {
 
     public void setRestartPolicy(RestartPolicy restartPolicy) {
         RestartPolicy = restartPolicy;
+    }
+
+    public EphemeralDisk getEphemeralDisk() {
+        return EphemeralDisk;
+    }
+
+    public void setEphemeralDisk(EphemeralDisk ephemeralDisk) {
+        EphemeralDisk = ephemeralDisk;
     }
 }

--- a/src/main/java/org/jenkinsci/plugins/nomad/NomadApi.java
+++ b/src/main/java/org/jenkinsci/plugins/nomad/NomadApi.java
@@ -134,7 +134,6 @@ public final class NomadApi {
                 new Resource(
                     template.getCpu(),
                     template.getMemory(),
-                    template.getDisk()
                 ),
                 new LogConfig(1, 10),
                 new Artifact[]{
@@ -146,7 +145,8 @@ public final class NomadApi {
                 "jenkins-slave-taskgroup",
                 1,
                 new Task[]{task},
-                new RestartPolicy(0, 10000000000L, 1000000000L, "fail")
+                new RestartPolicy(0, 10000000000L, 1000000000L, "fail"),
+                new EphemeralDisk(template.getDisk(), false, false)
         );
 
         Job job = new Job(

--- a/src/main/java/org/jenkinsci/plugins/nomad/NomadApi.java
+++ b/src/main/java/org/jenkinsci/plugins/nomad/NomadApi.java
@@ -133,7 +133,7 @@ public final class NomadApi {
                 buildDriverConfig(name, secret,template),
                 new Resource(
                     template.getCpu(),
-                    template.getMemory(),
+                    template.getMemory()
                 ),
                 new LogConfig(1, 10),
                 new Artifact[]{


### PR DESCRIPTION
Nomad 0.5 moves the diskMb resource parameter out into a group-level 'ephemeral_disk' object with size, migrate and sticky attributes. Unfortunately, it also then rejects job submissions using the old resource diskMb key.

The fix is to replace the diskMb attribute in the resource block with a group-level ephemeral_disk structure. I don’t know java and don’t understand the gson library enough to know how it turns the object var names into json keys so the EphemeralDisk object prob. has the wrong json label but I believe this PR is almost right.

I also don't know how to compile jenkins plugins and test them so this PR is untested but hopefully someone can point out the errors for me!

This relates to issue #11 