### PR TITLE
Add force_pull, volumes, switch user for Docker driver

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/nomad/Api/Task.java
+++ b/src/main/java/org/jenkinsci/plugins/nomad/Api/Task.java
@@ -5,6 +5,7 @@ import java.util.Map;
 public class Task {
     private String Name;
     private String Driver;
+    private String User;
     private Map<String, Object> Config;
     private Resource Resources;
     private LogConfig LogConfig;
@@ -13,6 +14,7 @@ public class Task {
     public Task(
             String name,
             String driver,
+            String user,
             Map<String, Object> config,
             Resource resources,
             LogConfig logConfig,
@@ -20,6 +22,7 @@ public class Task {
     ) {
         Name = name;
         Driver = driver;
+        User = user;
         Config = config;
         Resources = resources;
         LogConfig = logConfig;
@@ -40,6 +43,14 @@ public class Task {
 
     public void setDriver(String driver) {
         Driver = driver;
+    }
+
+    public String getUser() {
+        return User;
+    }
+
+    public void setUser(String user) {
+        User = user;
     }
 
     public Map<String, Object> getConfig() {

--- a/src/main/java/org/jenkinsci/plugins/nomad/NomadApi.java
+++ b/src/main/java/org/jenkinsci/plugins/nomad/NomadApi.java
@@ -119,7 +119,7 @@ public final class NomadApi {
             if (!hostVolumes.isEmpty()) {
                 driverConfig.put("volumes", StringUtils.split(hostVolumes, ","));
             }
-         
+
             driverConfig.put("args", args);
             driverConfig.put("force_pull", template.getForcePull());
             driverConfig.put("privileged", template.getPrivileged());
@@ -138,6 +138,7 @@ public final class NomadApi {
         Task task = new Task(
                 "jenkins-slave",
                 template.getDriver(),
+                template.getSwitchUser(),
                 buildDriverConfig(name, secret,template),
                 new Resource(
                     template.getCpu(),

--- a/src/main/java/org/jenkinsci/plugins/nomad/NomadApi.java
+++ b/src/main/java/org/jenkinsci/plugins/nomad/NomadApi.java
@@ -114,6 +114,11 @@ public final class NomadApi {
                 args.add(1, "/local/slave.jar");
             }
             driverConfig.put("image", template.getImage());
+
+            String hostVolumes = template.getHostVolumes();
+            if (!hostVolumes.isEmpty()) {
+                driverConfig.put("volumes", StringUtils.split(hostVolumes, ","));
+            }
          
             driverConfig.put("args", args);
             driverConfig.put("force_pull", template.getForcePull());

--- a/src/main/java/org/jenkinsci/plugins/nomad/NomadApi.java
+++ b/src/main/java/org/jenkinsci/plugins/nomad/NomadApi.java
@@ -116,6 +116,7 @@ public final class NomadApi {
             driverConfig.put("image", template.getImage());
          
             driverConfig.put("args", args);
+            driverConfig.put("force_pull", template.getForcePull());
             driverConfig.put("privileged", template.getPrivileged());
             driverConfig.put("network_mode", template.getNetwork());
         }

--- a/src/main/java/org/jenkinsci/plugins/nomad/NomadSlaveTemplate.java
+++ b/src/main/java/org/jenkinsci/plugins/nomad/NomadSlaveTemplate.java
@@ -44,6 +44,7 @@ public class NomadSlaveTemplate implements Describable<NomadSlaveTemplate> {
     private final String password;
     private final String prefixCmd;
     private final Boolean forcePull;
+    private final String hostVolumes;
     private final Node.Mode mode;
 
     private NomadCloud cloud;
@@ -71,7 +72,8 @@ public class NomadSlaveTemplate implements Describable<NomadSlaveTemplate> {
             Boolean privileged,
             String network,
             String prefixCmd,
-            Boolean forcePull
+            Boolean forcePull,
+            String hostVolumes
             ) {
         this.cpu = Integer.parseInt(cpu);
         this.memory = Integer.parseInt(memory);
@@ -97,6 +99,7 @@ public class NomadSlaveTemplate implements Describable<NomadSlaveTemplate> {
         this.network = network;
         this.prefixCmd = prefixCmd;
         this.forcePull = forcePull;
+        this.hostVolumes = hostVolumes;
         readResolve();
     }
 
@@ -220,5 +223,9 @@ public class NomadSlaveTemplate implements Describable<NomadSlaveTemplate> {
 
     public Boolean getForcePull() {
         return forcePull;
+    }
+
+    public String getHostVolumes() {
+        return hostVolumes;
     }
 }

--- a/src/main/java/org/jenkinsci/plugins/nomad/NomadSlaveTemplate.java
+++ b/src/main/java/org/jenkinsci/plugins/nomad/NomadSlaveTemplate.java
@@ -45,6 +45,7 @@ public class NomadSlaveTemplate implements Describable<NomadSlaveTemplate> {
     private final String prefixCmd;
     private final Boolean forcePull;
     private final String hostVolumes;
+    private final String switchUser;
     private final Node.Mode mode;
 
     private NomadCloud cloud;
@@ -73,7 +74,8 @@ public class NomadSlaveTemplate implements Describable<NomadSlaveTemplate> {
             String network,
             String prefixCmd,
             Boolean forcePull,
-            String hostVolumes
+            String hostVolumes,
+            String switchUser
             ) {
         this.cpu = Integer.parseInt(cpu);
         this.memory = Integer.parseInt(memory);
@@ -100,6 +102,7 @@ public class NomadSlaveTemplate implements Describable<NomadSlaveTemplate> {
         this.prefixCmd = prefixCmd;
         this.forcePull = forcePull;
         this.hostVolumes = hostVolumes;
+        this.switchUser = switchUser;
         readResolve();
     }
 
@@ -227,5 +230,9 @@ public class NomadSlaveTemplate implements Describable<NomadSlaveTemplate> {
 
     public String getHostVolumes() {
         return hostVolumes;
+    }
+
+    public String getSwitchUser() {
+        return switchUser;
     }
 }

--- a/src/main/java/org/jenkinsci/plugins/nomad/NomadSlaveTemplate.java
+++ b/src/main/java/org/jenkinsci/plugins/nomad/NomadSlaveTemplate.java
@@ -43,6 +43,7 @@ public class NomadSlaveTemplate implements Describable<NomadSlaveTemplate> {
     private final String username;
     private final String password;
     private final String prefixCmd;
+    private final Boolean forcePull;
     private final Node.Mode mode;
 
     private NomadCloud cloud;
@@ -69,7 +70,8 @@ public class NomadSlaveTemplate implements Describable<NomadSlaveTemplate> {
             String password,
             Boolean privileged,
             String network,
-            String prefixCmd
+            String prefixCmd,
+            Boolean forcePull
             ) {
         this.cpu = Integer.parseInt(cpu);
         this.memory = Integer.parseInt(memory);
@@ -94,6 +96,7 @@ public class NomadSlaveTemplate implements Describable<NomadSlaveTemplate> {
         this.privileged = privileged;
         this.network = network;
         this.prefixCmd = prefixCmd;
+        this.forcePull = forcePull;
         readResolve();
     }
 
@@ -213,5 +216,9 @@ public class NomadSlaveTemplate implements Describable<NomadSlaveTemplate> {
 
     public String getNetwork() {
         return network;
+    }
+
+    public Boolean getForcePull() {
+        return forcePull;
     }
 }

--- a/src/main/resources/org/jenkinsci/plugins/nomad/NomadSlaveTemplate/config.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/nomad/NomadSlaveTemplate/config.jelly
@@ -77,6 +77,9 @@
             <f:entry title="Prefix Command" field="preCmd">
                 <f:textbox name="prefixCmd" field="prefixCmd"/>
             </f:entry>
+            <f:entry title="Switch User" field="switchUser">
+                <f:textbox name="switchUser" field="switchUser" default="" />
+            </f:entry>
         </f:optionalBlock>
 
         <f:entry title="">

--- a/src/main/resources/org/jenkinsci/plugins/nomad/NomadSlaveTemplate/config.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/nomad/NomadSlaveTemplate/config.jelly
@@ -62,6 +62,9 @@
             <f:entry title="Password">
                 <f:password name="password" field="password" />
             </f:entry>
+            <f:entry title="Force Pull">
+                <f:checkbox name="forcePull" field="forcePull" default="false" value="${instance.forcePull}" />
+            </f:entry>
             <f:entry title="Privileged">
                 <f:checkbox name="privileged" field="privileged" default="false" value="${instance.privileged}" />
             </f:entry>

--- a/src/main/resources/org/jenkinsci/plugins/nomad/NomadSlaveTemplate/config.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/nomad/NomadSlaveTemplate/config.jelly
@@ -68,6 +68,9 @@
             <f:entry title="Privileged">
                 <f:checkbox name="privileged" field="privileged" default="false" value="${instance.privileged}" />
             </f:entry>
+            <f:entry title="Host Volumes">
+                <f:textbox name="hostVolumes" field="hostVolumes" default="" />
+            </f:entry>
             <f:entry title="Network">
                 <f:textbox name="network" field="network" default="bridge"/>
             </f:entry>

--- a/src/main/resources/org/jenkinsci/plugins/nomad/NomadSlaveTemplate/config.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/nomad/NomadSlaveTemplate/config.jelly
@@ -62,13 +62,13 @@
             <f:entry title="Password">
                 <f:password name="password" field="password" />
             </f:entry>
-            <f:entry title="Force Pull">
+            <f:entry title="Force Pull" field="forcePull">
                 <f:checkbox name="forcePull" field="forcePull" default="false" value="${instance.forcePull}" />
             </f:entry>
             <f:entry title="Privileged">
                 <f:checkbox name="privileged" field="privileged" default="false" value="${instance.privileged}" />
             </f:entry>
-            <f:entry title="Host Volumes">
+            <f:entry title="Host Volumes" field="hostVolumes">
                 <f:textbox name="hostVolumes" field="hostVolumes" default="" />
             </f:entry>
             <f:entry title="Network">

--- a/src/main/resources/org/jenkinsci/plugins/nomad/NomadSlaveTemplate/help-forcePull.html
+++ b/src/main/resources/org/jenkinsci/plugins/nomad/NomadSlaveTemplate/help-forcePull.html
@@ -1,0 +1,4 @@
+<div>
+    Always pull latest image instead of using existing local image. Should be<br>
+    checked if repository tags are mutable.
+</div>

--- a/src/main/resources/org/jenkinsci/plugins/nomad/NomadSlaveTemplate/help-hostVolumes.html
+++ b/src/main/resources/org/jenkinsci/plugins/nomad/NomadSlaveTemplate/help-hostVolumes.html
@@ -1,0 +1,7 @@
+<div>
+    A comma delimited list of host_path:container_path strings to bind host<br>
+    paths to container paths. Mounting host paths outside of the allocation<br>
+    directory can be disabled on clients by setting the docker.volumes.enabled<br>
+    option set to false. This will limit volumes to directories that exist<br>
+    inside the allocation directory.
+</div>

--- a/src/main/resources/org/jenkinsci/plugins/nomad/NomadSlaveTemplate/help-switchUser.html
+++ b/src/main/resources/org/jenkinsci/plugins/nomad/NomadSlaveTemplate/help-switchUser.html
@@ -1,0 +1,4 @@
+<div>
+    Change user ID instead of running Jenkins Slave as root. Username is<br>
+    expected and su command must be present.
+</div>

--- a/src/test/java/org/jenkinsci/plugins/nomad/NomadApiTest.java
+++ b/src/test/java/org/jenkinsci/plugins/nomad/NomadApiTest.java
@@ -19,7 +19,8 @@ public class NomadApiTest {
     private NomadSlaveTemplate slaveTemplate = new NomadSlaveTemplate(
             "300", "256", "100",
             null, constraintTest, "remoteFs", "3","1", Node.Mode.NORMAL,
-            "ams", "0", "image", "dc01", "", "", false, "bridge",""
+            "ams", "0", "image", "dc01", "", "", false, "bridge",
+            "", true
     );
 
     private NomadCloud nomadCloud = new NomadCloud(
@@ -45,6 +46,7 @@ public class NomadApiTest {
         assertTrue(job.contains("\"GetterSource\":\"slaveUrl\""));
         assertTrue(job.contains("\"privileged\":false"));
         assertTrue(job.contains("\"network_mode\":\"bridge\""));
+        assertTrue(job.contains("\"force_pull\":true"));
     }
 
 }

--- a/src/test/java/org/jenkinsci/plugins/nomad/NomadApiTest.java
+++ b/src/test/java/org/jenkinsci/plugins/nomad/NomadApiTest.java
@@ -20,7 +20,7 @@ public class NomadApiTest {
             "300", "256", "100",
             null, constraintTest, "remoteFs", "3","1", Node.Mode.NORMAL,
             "ams", "0", "image", "dc01", "", "", false, "bridge",
-            "", true, "/mnt:/mnt"
+            "", true, "/mnt:/mnt", "jenkins"
     );
 
     private NomadCloud nomadCloud = new NomadCloud(
@@ -48,6 +48,7 @@ public class NomadApiTest {
         assertTrue(job.contains("\"network_mode\":\"bridge\""));
         assertTrue(job.contains("\"force_pull\":true"));
         assertTrue(job.contains("\"volumes\":[\"/mnt:/mnt\"]"));
+        assertTrue(job.contains("\"User\":\"jenkins\""));
     }
 
 }

--- a/src/test/java/org/jenkinsci/plugins/nomad/NomadApiTest.java
+++ b/src/test/java/org/jenkinsci/plugins/nomad/NomadApiTest.java
@@ -20,7 +20,7 @@ public class NomadApiTest {
             "300", "256", "100",
             null, constraintTest, "remoteFs", "3","1", Node.Mode.NORMAL,
             "ams", "0", "image", "dc01", "", "", false, "bridge",
-            "", true
+            "", true, "/mnt:/mnt"
     );
 
     private NomadCloud nomadCloud = new NomadCloud(
@@ -47,6 +47,7 @@ public class NomadApiTest {
         assertTrue(job.contains("\"privileged\":false"));
         assertTrue(job.contains("\"network_mode\":\"bridge\""));
         assertTrue(job.contains("\"force_pull\":true"));
+        assertTrue(job.contains("\"volumes\":[\"/mnt:/mnt\"]"));
     }
 
 }


### PR DESCRIPTION
MR is more or less up for discussion. I'm ok with splitting it up into multiple MRs, if required, or re-working some features if necessary.

MR adds the following features:
* force_pull for Docker driver
* mount host paths into Docker container aka "volumes"
* ability to switch user and drop root, resp. run Jenkins Slave as a non-root user, because why not?

Cheers :)