### PR TITLE
Add a flag whether to reuse containers

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/nomad/NomadComputer.java
+++ b/src/main/java/org/jenkinsci/plugins/nomad/NomadComputer.java
@@ -13,15 +13,21 @@ public class NomadComputer extends AbstractCloudComputer<NomadSlave> {
 
     private final NomadCloud cloud;
 
+    private final Boolean reusable;
+
     public NomadComputer(NomadSlave slave) {
         super(slave);
 
         this.cloud = slave.getCloud();
+        this.reusable = slave.getReusable();
     }
 
     @Override
     public void taskAccepted(Executor executor, Queue.Task task) {
         super.taskAccepted(executor, task);
+        if (!reusable) {
+            setAcceptingTasks(false);
+        }
         LOGGER.log(Level.INFO, " Computer " + this + ": task accepted");
     }
 

--- a/src/main/java/org/jenkinsci/plugins/nomad/NomadSlave.java
+++ b/src/main/java/org/jenkinsci/plugins/nomad/NomadSlave.java
@@ -17,6 +17,8 @@ public class NomadSlave extends AbstractCloudSlave implements EphemeralNode {
 
     private final NomadCloud cloud;
 
+    private final Boolean reusable;
+
     public NomadSlave(
         NomadCloud cloud,
         String name,
@@ -39,6 +41,7 @@ public class NomadSlave extends AbstractCloudSlave implements EphemeralNode {
         );
 
         this.cloud = cloud;
+        this.reusable = template.getReusable();
     }
 
     @Override
@@ -76,5 +79,9 @@ public class NomadSlave extends AbstractCloudSlave implements EphemeralNode {
 
     public NomadCloud getCloud() {
         return cloud;
+    }
+
+    public Boolean getReusable() {
+        return reusable;
     }
 }

--- a/src/main/java/org/jenkinsci/plugins/nomad/NomadSlaveTemplate.java
+++ b/src/main/java/org/jenkinsci/plugins/nomad/NomadSlaveTemplate.java
@@ -27,6 +27,7 @@ public class NomadSlaveTemplate implements Describable<NomadSlaveTemplate> {
     private static final Logger LOGGER = Logger.getLogger(NomadSlaveTemplate.class.getName());
 
     private final int idleTerminationInMinutes;
+    private final Boolean reusable;
     private final int numExecutors;
 
     private final int cpu;
@@ -62,6 +63,7 @@ public class NomadSlaveTemplate implements Describable<NomadSlaveTemplate> {
             List<? extends NomadConstraintTemplate> constraints,
             String remoteFs,
             String idleTerminationInMinutes,
+            Boolean reusable,
             String numExecutors,
             Node.Mode mode,
             String region,
@@ -82,6 +84,7 @@ public class NomadSlaveTemplate implements Describable<NomadSlaveTemplate> {
         this.disk = Integer.parseInt(disk);
         this.priority = Integer.parseInt(priority);
         this.idleTerminationInMinutes = Integer.parseInt(idleTerminationInMinutes);
+        this.reusable = reusable;
         this.numExecutors = Integer.parseInt(numExecutors);
         this.mode = mode;
         this.remoteFs = remoteFs;
@@ -166,6 +169,10 @@ public class NomadSlaveTemplate implements Describable<NomadSlaveTemplate> {
 
     public int getIdleTerminationInMinutes() {
         return idleTerminationInMinutes;
+    }
+
+    public Boolean getReusable() {
+        return reusable;
     }
 
     public String getRegion() {

--- a/src/main/resources/org/jenkinsci/plugins/nomad/NomadSlaveTemplate/config.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/nomad/NomadSlaveTemplate/config.jelly
@@ -42,6 +42,10 @@
             <f:textbox default="10" />
         </f:entry>
 
+        <f:entry title="Reusable">
+            <f:checkbox name="reusable" field="reusable" default="true" value="${instance.reusable}" />
+        </f:entry>
+
         <f:entry title="Executors" field="numExecutors">
             <f:textbox default="1" />
         </f:entry>

--- a/src/main/resources/org/jenkinsci/plugins/nomad/NomadSlaveTemplate/help-reusable.html
+++ b/src/main/resources/org/jenkinsci/plugins/nomad/NomadSlaveTemplate/help-reusable.html
@@ -1,0 +1,5 @@
+<div>
+    Toggle whether to reuse a container after a job.<br />
+    Enable this to reuse a container for other jobs (faster start times)<br />
+    Disable this to always have a new (clean) container for every job.
+</div>

--- a/src/test/java/org/jenkinsci/plugins/nomad/NomadApiTest.java
+++ b/src/test/java/org/jenkinsci/plugins/nomad/NomadApiTest.java
@@ -18,7 +18,7 @@ public class NomadApiTest {
     private List<NomadConstraintTemplate> constraintTest = new ArrayList<NomadConstraintTemplate>();
     private NomadSlaveTemplate slaveTemplate = new NomadSlaveTemplate(
             "300", "256", "100",
-            null, constraintTest, "remoteFs", "3","1", Node.Mode.NORMAL,
+            null, constraintTest, "remoteFs", "3", true, "1", Node.Mode.NORMAL,
             "ams", "0", "image", "dc01", "", "", false, "bridge",
             "", true, "/mnt:/mnt", "jenkins"
     );


### PR DESCRIPTION
Since containers are easy and cheap to start and destroy, I find it more
convenient to be certain any job will start in a fresh container. Any
residue from a previous job (might be from a different team) should be
gone completely.

For this, it is not sufficient to change "Idle termination time" to `0`,
since queued jobs will still be executed on used containers.

Instead, I added a flag "Reusable", which will in effect suspend a
"computer" as soon as a job is scheduled on it. This means the computer
will remain idle after the job is finished, and therefore the "Idle
termination time" (still `0` obviously) will take effect. In practice
every job will now run on a fresh container.