### PR TITLE
add JENKINS_TUNNEL

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -12,7 +12,7 @@
   </parent>
 
   <artifactId>nomad</artifactId>
-  <version>0.5.2-SNAPSHOT</version>
+  <version>0.6.0-SNAPSHOT</version>
   <packaging>hpi</packaging>
 
   <name>Nomad Plugin</name>
@@ -32,7 +32,7 @@
     <developerConnection>scm:git:ssh://git@github.com/jenkinsci/nomad-plugin.git
     </developerConnection>
     <url>https://github.com/jenkinsci/nomad-plugin</url>
-    <tag>v0.5.1</tag>
+    <tag>v0.6.0</tag>
   </scm>
 
   <properties>

--- a/pom.xml
+++ b/pom.xml
@@ -1,12 +1,14 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
   <modelVersion>4.0.0</modelVersion>
 
   <parent>
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>
-    <version>2.15</version>
-    <relativePath />
+    <version>3.9</version>
+    <relativePath/>
   </parent>
 
   <artifactId>nomad</artifactId>
@@ -27,12 +29,15 @@
 
   <scm>
     <connection>scm:git:ssh://github.com/jenkinsci/nomad-plugin.git</connection>
-    <developerConnection>scm:git:ssh://git@github.com/jenkinsci/nomad-plugin.git</developerConnection>
+    <developerConnection>scm:git:ssh://git@github.com/jenkinsci/nomad-plugin.git
+    </developerConnection>
     <url>https://github.com/jenkinsci/nomad-plugin</url>
     <tag>v0.5.1</tag>
   </scm>
 
   <properties>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    <java.level>8</java.level>
     <findbugs.failOnError>false</findbugs.failOnError>
   </properties>
 
@@ -62,17 +67,17 @@
     <dependency>
       <groupId>com.squareup.okhttp3</groupId>
       <artifactId>okhttp</artifactId>
-      <version>3.2.0</version>
+      <version>3.10.0</version>
     </dependency>
     <dependency>
       <groupId>com.google.code.gson</groupId>
       <artifactId>gson</artifactId>
-      <version>2.6.2</version>
+      <version>2.8.4</version>
     </dependency>
     <dependency>
       <groupId>org.json</groupId>
       <artifactId>json</artifactId>
-      <version>20090211</version>
+      <version>20180130</version>
     </dependency>
 
     <!-- TESTS -->

--- a/src/main/java/org/jenkinsci/plugins/nomad/Api/Network.java
+++ b/src/main/java/org/jenkinsci/plugins/nomad/Api/Network.java
@@ -1,0 +1,30 @@
+package org.jenkinsci.plugins.nomad.Api;
+
+import java.util.List;
+
+public class Network {
+
+    private Integer MBits;
+    private List<Port> ReservedPorts;
+
+    public Network(Integer mbits, List<Port> reservedPorts) {
+        MBits = mbits;
+        ReservedPorts = reservedPorts;
+    }
+
+    public Integer getMBits() {
+        return MBits;
+    }
+
+    public void setMBits(Integer MBits) {
+        this.MBits = MBits;
+    }
+
+    public List<Port> getReservedPorts() {
+        return ReservedPorts;
+    }
+
+    public void setReservedPorts(List<Port> reservedPorts) {
+        this.ReservedPorts = reservedPorts;
+    }
+}

--- a/src/main/java/org/jenkinsci/plugins/nomad/Api/Port.java
+++ b/src/main/java/org/jenkinsci/plugins/nomad/Api/Port.java
@@ -1,0 +1,35 @@
+package org.jenkinsci.plugins.nomad.Api;
+
+import org.jenkinsci.plugins.nomad.NomadPortTemplate;
+
+public class Port {
+
+    private String Label;
+    private Integer Value;
+
+    public Port(String label, Integer value) {
+        this.Label = label;
+        this.Value = value;
+    }
+
+    public Port(NomadPortTemplate template) {
+        this.Label = template.getLabel();
+        this.Value = Integer.parseInt(template.getValue());
+    }
+
+    public String getLabel() {
+        return Label;
+    }
+
+    public void setLabel(String label) {
+        this.Label = label;
+    }
+
+    public Integer getValue() {
+        return Value;
+    }
+
+    public void setValue(Integer value) {
+        this.Value = value;
+    }
+}

--- a/src/main/java/org/jenkinsci/plugins/nomad/Api/PortGroup.java
+++ b/src/main/java/org/jenkinsci/plugins/nomad/Api/PortGroup.java
@@ -1,0 +1,21 @@
+package org.jenkinsci.plugins.nomad.Api;
+
+import org.jenkinsci.plugins.nomad.NomadPortTemplate;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class PortGroup {
+
+    private List<Port> ports = new ArrayList<>();
+
+    public PortGroup(List<? extends NomadPortTemplate> portTemplate) {
+        for (NomadPortTemplate template : portTemplate) {
+            ports.add(new Port(template));
+        }
+    }
+
+    public List<Port> getPorts() {
+        return ports;
+    }
+}

--- a/src/main/java/org/jenkinsci/plugins/nomad/Api/Resource.java
+++ b/src/main/java/org/jenkinsci/plugins/nomad/Api/Resource.java
@@ -1,12 +1,25 @@
 package org.jenkinsci.plugins.nomad.Api;
 
+import java.util.List;
+
 public class Resource {
+
     private Integer CPU;
     private Integer MemoryMB;
-	
-    public Resource(Integer CPU, Integer memoryMB) {
+    private List<Network> Networks;
+
+    public Resource(Integer CPU, Integer memoryMB, List<Network> networks) {
         this.CPU = CPU;
-        MemoryMB = memoryMB;
+        this.MemoryMB = memoryMB;
+        this.Networks = networks;
+    }
+
+    public List<Network> getNetworks() {
+        return Networks;
+    }
+
+    public void setNetworks(List<Network> networks) {
+        this.Networks = networks;
     }
 
     public Integer getCPU() {
@@ -22,6 +35,6 @@ public class Resource {
     }
 
     public void setMemoryMB(Integer memoryMB) {
-        MemoryMB = memoryMB;
+        this.MemoryMB = memoryMB;
     }
 }

--- a/src/main/java/org/jenkinsci/plugins/nomad/NomadPortTemplate.java
+++ b/src/main/java/org/jenkinsci/plugins/nomad/NomadPortTemplate.java
@@ -1,0 +1,61 @@
+package org.jenkinsci.plugins.nomad;
+
+import hudson.Extension;
+import hudson.model.Describable;
+import hudson.model.Descriptor;
+import jenkins.model.Jenkins;
+import org.kohsuke.stapler.DataBoundConstructor;
+
+public class NomadPortTemplate implements Describable<NomadPortTemplate> {
+
+    private final String label;
+    private final String value;
+
+    private NomadSlaveTemplate slave;
+
+    @DataBoundConstructor
+    public NomadPortTemplate(String label, String value) {
+        this.label = label;
+        this.value = value;
+        readResolve();
+    }
+
+    protected Object readResolve() {
+        return this;
+    }
+
+    @Override
+    @SuppressWarnings("unchecked")
+    public Descriptor<NomadPortTemplate> getDescriptor() {
+        return Jenkins.getInstance().getDescriptor(getClass());
+    }
+
+    public String getLabel() {
+        return label;
+    }
+
+    public String getValue() {
+        return value;
+    }
+
+    public NomadSlaveTemplate getNomadSlaveTemplate() {
+        return slave;
+    }
+
+    public void setNomadSlaveTemplate(NomadSlaveTemplate slave) {
+        this.slave = slave;
+    }
+
+    @Extension
+    public static final class DescriptorImpl extends Descriptor<NomadPortTemplate> {
+
+        public DescriptorImpl() {
+            load();
+        }
+
+        @Override
+        public String getDisplayName() {
+            return null;
+        }
+    }
+}

--- a/src/main/java/org/jenkinsci/plugins/nomad/NomadSlaveTemplate.java
+++ b/src/main/java/org/jenkinsci/plugins/nomad/NomadSlaveTemplate.java
@@ -1,8 +1,6 @@
 package org.jenkinsci.plugins.nomad;
 
 import hudson.Extension;
-import org.kohsuke.stapler.DataBoundConstructor;
-
 import hudson.Util;
 import hudson.model.Describable;
 import hudson.model.Descriptor;
@@ -10,16 +8,12 @@ import hudson.model.Label;
 import hudson.model.Node;
 import hudson.model.labels.LabelAtom;
 import jenkins.model.Jenkins;
+import org.kohsuke.stapler.DataBoundConstructor;
 
-import java.lang.reflect.Type;
-import com.google.gson.reflect.TypeToken;
-
-import javax.annotation.Nullable;
-import java.util.*;
+import java.util.Collections;
+import java.util.List;
+import java.util.Set;
 import java.util.logging.Logger;
-
-import com.google.gson.Gson;
-import com.google.gson.JsonObject;
 
 public class NomadSlaveTemplate implements Describable<NomadSlaveTemplate> {
 
@@ -48,6 +42,7 @@ public class NomadSlaveTemplate implements Describable<NomadSlaveTemplate> {
     private final String hostVolumes;
     private final String switchUser;
     private final Node.Mode mode;
+    private final List<? extends NomadPortTemplate> ports;
 
     private NomadCloud cloud;
     private String driver;
@@ -77,8 +72,9 @@ public class NomadSlaveTemplate implements Describable<NomadSlaveTemplate> {
             String prefixCmd,
             Boolean forcePull,
             String hostVolumes,
-            String switchUser
-            ) {
+            String switchUser,
+            List<? extends NomadPortTemplate> ports
+    ) {
         this.cpu = Integer.parseInt(cpu);
         this.memory = Integer.parseInt(memory);
         this.disk = Integer.parseInt(disk);
@@ -106,6 +102,11 @@ public class NomadSlaveTemplate implements Describable<NomadSlaveTemplate> {
         this.forcePull = forcePull;
         this.hostVolumes = hostVolumes;
         this.switchUser = switchUser;
+        if (ports == null) {
+            this.ports = Collections.emptyList();
+        } else {
+            this.ports = ports;
+        }
         readResolve();
     }
 
@@ -114,7 +115,7 @@ public class NomadSlaveTemplate implements Describable<NomadSlaveTemplate> {
         return this;
     }
 
-   
+
     @Extension
     public static final class DescriptorImpl extends Descriptor<NomadSlaveTemplate> {
 
@@ -145,11 +146,10 @@ public class NomadSlaveTemplate implements Describable<NomadSlaveTemplate> {
     public int getNumExecutors() {
         return numExecutors;
     }
-    
+
     public Node.Mode getMode() {
         return mode;
     }
-
 
     public int getCpu() {
         return cpu;
@@ -214,7 +214,7 @@ public class NomadSlaveTemplate implements Describable<NomadSlaveTemplate> {
     public String getPassword() {
         return password;
     }
-    
+
     public String getPrefixCmd() {
         return prefixCmd;
     }
@@ -241,5 +241,9 @@ public class NomadSlaveTemplate implements Describable<NomadSlaveTemplate> {
 
     public String getSwitchUser() {
         return switchUser;
+    }
+
+    public List<? extends NomadPortTemplate> getPorts() {
+        return Collections.unmodifiableList(ports);
     }
 }

--- a/src/main/resources/org/jenkinsci/plugins/nomad/NomadCloud/config.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/nomad/NomadCloud/config.jelly
@@ -14,6 +14,10 @@
     <f:textbox default="${instance.getJenkinsUrl()}"/>
   </f:entry>
 
+  <f:entry title="Jenkins Tunnel" field="jenkinsTunnel" description="Jenkins Tunnel [HOST:PORT] Connect to the specified host and port, instead of connecting directly to Jenkins. Useful when connection to Hudson needs to be tunneled.">
+    <f:textbox default="${instance.getJenkinsTunnel()}"/>
+  </f:entry>
+
   <f:entry title="Jenkins Slave URL" field="slaveUrl" description="Jenkins slave URL">
     <f:textbox default="${instance.getSlaveUrl()}"/>
   </f:entry>

--- a/src/main/resources/org/jenkinsci/plugins/nomad/NomadPortTemplate/config.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/nomad/NomadPortTemplate/config.jelly
@@ -1,0 +1,21 @@
+<?jelly escape-by-default='false'?>
+
+<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
+
+	<table width="100%">
+
+		<f:entry title="Label" field="label">
+            <f:textbox/>
+        </f:entry>
+
+        <f:entry title="Value" field="value">
+            <f:textbox/>
+        </f:entry>
+
+        <f:entry>
+            <f:repeatableDeleteButton />
+        </f:entry>
+
+    </table>
+
+</j:jelly>

--- a/src/main/resources/org/jenkinsci/plugins/nomad/NomadSlaveTemplate/config.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/nomad/NomadSlaveTemplate/config.jelly
@@ -86,6 +86,12 @@
             </f:entry>
         </f:optionalBlock>
 
+        <f:entry title="Ports" help="/plugin/nomad/help-ports.html">
+            <f:repeatable field="ports">
+            <st:include page="/org/jenkinsci/plugins/nomad/NomadPortTemplate/config.jelly" class="org.jenkinsci.plugins.nomad.NomadPortTemplate$DescriptorImpl"/>
+            </f:repeatable>
+        </f:entry>
+
         <f:entry title="">
             <div align="right">
                 <f:repeatableDeleteButton />

--- a/src/main/resources/org/jenkinsci/plugins/nomad/NomadSlaveTemplate/help-reusable.html
+++ b/src/main/resources/org/jenkinsci/plugins/nomad/NomadSlaveTemplate/help-reusable.html
@@ -1,5 +1,5 @@
 <div>
-    Toggle whether to reuse a container after a job.<br />
-    Enable this to reuse a container for other jobs (faster start times)<br />
+    Toggle whether to reuse a container after a job.<br/>
+    Enable this to reuse a container for other jobs (faster start times)<br/>
     Disable this to always have a new (clean) container for every job.
 </div>

--- a/src/main/webapp/help-constraints.html
+++ b/src/main/webapp/help-constraints.html
@@ -1,3 +1,4 @@
 <div>
-	Read the JSON synax and Constraints API pages on nomadproject.io to see how to apply constraints (these apply on the Job level)
+    Read the JSON syntax and Constraints API pages on nomadproject.io to see how to apply constraints
+    (these apply on the Job level).
 </div>

--- a/src/main/webapp/help-ports.html
+++ b/src/main/webapp/help-ports.html
@@ -1,0 +1,4 @@
+<div>
+    Read the JSON syntax and Network Ports API pages on nomadproject.io to see how to set ports (these
+    apply on the Job level).
+</div>

--- a/src/test/java/org/jenkinsci/plugins/nomad/NomadApiTest.java
+++ b/src/test/java/org/jenkinsci/plugins/nomad/NomadApiTest.java
@@ -4,10 +4,11 @@ import hudson.model.Node;
 import org.junit.Before;
 import org.junit.Test;
 
-import java.util.Collections;
-import static org.junit.Assert.assertTrue;
-import java.util.List;
 import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+import static org.junit.Assert.assertTrue;
 
 /**
  * @author Yegor Andreenko
@@ -20,13 +21,15 @@ public class NomadApiTest {
             "300", "256", "100",
             null, constraintTest, "remoteFs", "3", true, "1", Node.Mode.NORMAL,
             "ams", "0", "image", "dc01", "", "", false, "bridge",
-            "", true, "/mnt:/mnt", "jenkins"
+            "", true, "/mnt:/mnt", "jenkins", new ArrayList<NomadPortTemplate>() {
+    }
     );
 
     private NomadCloud nomadCloud = new NomadCloud(
             "nomad",
             "nomadUrl",
             "jenkinsUrl",
+            "jenkinsTunnel",
             "slaveUrl",
             Collections.singletonList(slaveTemplate));
 
@@ -37,7 +40,7 @@ public class NomadApiTest {
 
     @Test
     public void testStartSlave() {
-        String job = nomadApi.buildSlaveJob("slave-1","secret", slaveTemplate);
+        String job = nomadApi.buildSlaveJob("slave-1", "secret", slaveTemplate);
 
         assertTrue(job.contains("\"Region\":\"ams\""));
         assertTrue(job.contains("\"CPU\":300"));

--- a/src/test/java/org/jenkinsci/plugins/nomad/NomadCloudTest.java
+++ b/src/test/java/org/jenkinsci/plugins/nomad/NomadCloudTest.java
@@ -20,6 +20,7 @@ public class NomadCloudTest {
             "nomad",
             "nomadUrl",
             "jenkinsUrl",
+            "jenkinsTunnel",
             "slaveUrl",
             Collections.singletonList(slaveTemplate));
 


### PR DESCRIPTION
The `slave.jar` needs to be invoked with `-tunnel` if Jenkins is behind a proxy:

```
$ java -cp ~/Downloads/slave.jar hudson.remoting.jnlp.Main                              
two arguments required, but got []
java -jar agent.jar [options...] <secret key> <agent name>
 -agentLog FILE                  : Local agent error log destination (overrides
                                   workDir)
 -cert VAL                       : Specify additional X.509 encoded PEM
                                   certificates to trust when connecting to
                                   Jenkins root URLs. If starting with @ then
                                   the remainder is assumed to be the name of
                                   the certificate file to read.
 -credentials USER:PASSWORD      : HTTP BASIC AUTH header to pass in for making
                                   HTTP requests.
 -disableHttpsCertValidation     : Ignore SSL validation errors - use as a last
                                   resort only.
 -failIfWorkDirIsMissing         : Fails the initialization if the requested
                                   workDir or internalDir are missing ('false'
                                   by default)
 -headless                       : Run in headless mode, without GUI
 -internalDir VAL                : Specifies a name of the internal files
                                   within a working directory ('remoting' by
                                   default)
 -jar-cache DIR                  : Cache directory that stores jar files sent
                                   from the master
 -loggingConfig FILE             : Path to the property file with
                                   java.util.logging settings
 -noKeepAlive                    : Disable TCP socket keep alive on connection
                                   to the master.
 -noreconnect                    : If the connection ends, don't retry and just
                                   exit.
 -proxyCredentials USER:PASSWORD : HTTP BASIC AUTH header to pass in for making
                                   HTTP authenticated proxy requests.
 -tunnel HOST:PORT               : Connect to the specified host and port,
                                   instead of connecting directly to Jenkins.
                                   Useful when connection to Hudson needs to be
                                   tunneled. Can be also HOST: or :PORT, in
                                   which case the missing portion will be
                                   auto-configured like the default behavior
 -url URL                        : Specify the Jenkins root URLs to connect to.
 -workDir FILE                   : Declares the working directory of the
                                   remoting instance (stores cache and logs by
                                   default)
```
Fixes #30. `nomad-0.6` [hpi](https://github.com/spoud/nomad-plugin/releases/download/nomad-0.6/nomad.hpi).