### PR TITLE
Add cap_add and extra_hosts to Nomad Docker option

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/nomad/NomadApi.java
+++ b/src/main/java/org/jenkinsci/plugins/nomad/NomadApi.java
@@ -124,6 +124,16 @@ public final class NomadApi {
             driverConfig.put("force_pull", template.getForcePull());
             driverConfig.put("privileged", template.getPrivileged());
             driverConfig.put("network_mode", template.getNetwork());
+
+            String extraHosts = template.getExtraHosts();
+            if (!extraHosts.isEmpty()) {
+                driverConfig.put("extra_hosts", StringUtils.split(extraHosts, ", "));
+            }
+
+            String capAdd = template.getCapAdd();
+            if (!capAdd.isEmpty()) {
+                driverConfig.put("cap_add", StringUtils.split(capAdd, ", "));
+            }
         }
 
         return driverConfig;

--- a/src/main/java/org/jenkinsci/plugins/nomad/NomadSlaveTemplate.java
+++ b/src/main/java/org/jenkinsci/plugins/nomad/NomadSlaveTemplate.java
@@ -48,6 +48,8 @@ public class NomadSlaveTemplate implements Describable<NomadSlaveTemplate> {
     private final String hostVolumes;
     private final String switchUser;
     private final Node.Mode mode;
+    private final String extraHosts;
+    private final String capAdd;
 
     private NomadCloud cloud;
     private String driver;
@@ -77,7 +79,9 @@ public class NomadSlaveTemplate implements Describable<NomadSlaveTemplate> {
             String prefixCmd,
             Boolean forcePull,
             String hostVolumes,
-            String switchUser
+            String switchUser,
+            String extraHosts,
+            String capAdd
             ) {
         this.cpu = Integer.parseInt(cpu);
         this.memory = Integer.parseInt(memory);
@@ -106,6 +110,8 @@ public class NomadSlaveTemplate implements Describable<NomadSlaveTemplate> {
         this.forcePull = forcePull;
         this.hostVolumes = hostVolumes;
         this.switchUser = switchUser;
+        this.extraHosts = extraHosts;
+        this.capAdd = capAdd;
         readResolve();
     }
 
@@ -241,5 +247,13 @@ public class NomadSlaveTemplate implements Describable<NomadSlaveTemplate> {
 
     public String getSwitchUser() {
         return switchUser;
+    }
+
+    public String getCapAdd() {
+        return capAdd;
+    }
+
+    public String getExtraHosts() {
+        return extraHosts;
     }
 }

--- a/src/main/resources/org/jenkinsci/plugins/nomad/NomadSlaveTemplate/config.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/nomad/NomadSlaveTemplate/config.jelly
@@ -84,6 +84,12 @@
             <f:entry title="Switch User" field="switchUser">
                 <f:textbox name="switchUser" field="switchUser" default="" />
             </f:entry>
+            <f:entry title="Extra Hosts" field="extraHosts">
+                <f:textbox name="extraHosts" field="extraHosts" default="" />
+            </f:entry>
+            <f:entry title="Add Capabilities" field="capAdd">
+                <f:textbox name="capAdd" field="capAdd" default="" />
+            </f:entry>
         </f:optionalBlock>
 
         <f:entry title="">

--- a/src/main/resources/org/jenkinsci/plugins/nomad/NomadSlaveTemplate/help-capAdd.html
+++ b/src/main/resources/org/jenkinsci/plugins/nomad/NomadSlaveTemplate/help-capAdd.html
@@ -1,0 +1,3 @@
+<div>
+    A comma delimited list of capabilities to pass directly to --cap-add.
+</div>

--- a/src/main/resources/org/jenkinsci/plugins/nomad/NomadSlaveTemplate/help-extraHosts.html
+++ b/src/main/resources/org/jenkinsci/plugins/nomad/NomadSlaveTemplate/help-extraHosts.html
@@ -1,0 +1,3 @@
+<div>
+    A comma delimited list of host:IP strings to be added to /etc/hosts.
+</div>

--- a/src/test/java/org/jenkinsci/plugins/nomad/NomadApiTest.java
+++ b/src/test/java/org/jenkinsci/plugins/nomad/NomadApiTest.java
@@ -20,7 +20,7 @@ public class NomadApiTest {
             "300", "256", "100",
             null, constraintTest, "remoteFs", "3", true, "1", Node.Mode.NORMAL,
             "ams", "0", "image", "dc01", "", "", false, "bridge",
-            "", true, "/mnt:/mnt", "jenkins"
+            "", true, "/mnt:/mnt", "jenkins", "my_host:192.168.1.1,", "SYS_ADMIN, SYSLOG"
     );
 
     private NomadCloud nomadCloud = new NomadCloud(
@@ -49,6 +49,8 @@ public class NomadApiTest {
         assertTrue(job.contains("\"force_pull\":true"));
         assertTrue(job.contains("\"volumes\":[\"/mnt:/mnt\"]"));
         assertTrue(job.contains("\"User\":\"jenkins\""));
+        assertTrue(job.contains("\"extra_hosts\":[\"my_host:192.168.1.1\"]"));
+        assertTrue(job.contains("\"cap_add\":[\"SYS_ADMIN\",\"SYSLOG\"]"));
     }
 
 }


### PR DESCRIPTION
This allows the user to configure extra_hosts and cap_add to the
requested docker job.  The split takes either comma or space,
effectively trimming off any extra spaces.