### PR TITLE
Adding Orphaned worker cleanup and configurable prefix for workers

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
   </parent>
 
   <artifactId>nomad</artifactId>
-  <version>0.4</version>
+  <version>0.5-SNAPSHOT</version>
   <packaging>hpi</packaging>
 
   <name>Nomad Plugin</name>
@@ -29,7 +29,7 @@
     <connection>scm:git:ssh://github.com/jenkinsci/nomad-plugin.git</connection>
     <developerConnection>scm:git:ssh://git@github.com/jenkinsci/nomad-plugin.git</developerConnection>
     <url>https://github.com/jenkinsci/nomad-plugin</url>
-    <tag>nomad-0.4</tag>
+    <tag>nomad-0.3.1</tag>
   </scm>
 
   <properties>

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
   </parent>
 
   <artifactId>nomad</artifactId>
-  <version>0.3.2-SNAPSHOT</version>
+  <version>0.4</version>
   <packaging>hpi</packaging>
 
   <name>Nomad Plugin</name>
@@ -29,7 +29,7 @@
     <connection>scm:git:ssh://github.com/jenkinsci/nomad-plugin.git</connection>
     <developerConnection>scm:git:ssh://git@github.com/jenkinsci/nomad-plugin.git</developerConnection>
     <url>https://github.com/jenkinsci/nomad-plugin</url>
-    <tag>nomad-0.3.1</tag>
+    <tag>nomad-0.4</tag>
   </scm>
 
   <properties>

--- a/pom.xml
+++ b/pom.xml
@@ -26,8 +26,8 @@
   </licenses>
 
   <scm>
-    <connection>scm:git:https://github.com/jenkinsci/nomad-plugin.git</connection>
-    <developerConnection>scm:git:https://github.com/jenkinsci/nomad-plugin.git</developerConnection>
+    <connection>scm:git:ssh://github.com/jenkinsci/nomad-plugin.git</connection>
+    <developerConnection>scm:git:ssh://git@github.com/jenkinsci/nomad-plugin.git</developerConnection>
     <url>https://github.com/jenkinsci/nomad-plugin</url>
     <tag>nomad-0.3.1</tag>
   </scm>

--- a/src/main/java/org/jenkinsci/plugins/nomad/NomadCloud.java
+++ b/src/main/java/org/jenkinsci/plugins/nomad/NomadCloud.java
@@ -1,6 +1,5 @@
 package org.jenkinsci.plugins.nomad;
 
-import com.google.common.base.Optional;
 import com.google.common.base.Strings;
 import hudson.Extension;
 import hudson.model.Descriptor;

--- a/src/main/java/org/jenkinsci/plugins/nomad/NomadCloud.java
+++ b/src/main/java/org/jenkinsci/plugins/nomad/NomadCloud.java
@@ -1,19 +1,22 @@
 package org.jenkinsci.plugins.nomad;
 
-import org.kohsuke.stapler.DataBoundConstructor;
-import org.kohsuke.stapler.QueryParameter;
-import hudson.Extension;
-
-import hudson.slaves.*;
-import okhttp3.OkHttpClient;
-import okhttp3.Request;
 import com.google.common.base.Optional;
 import com.google.common.base.Strings;
+import hudson.Extension;
 import hudson.model.Descriptor;
-import hudson.util.FormValidation;
 import hudson.model.Label;
 import hudson.model.Node;
+import hudson.slaves.AbstractCloudImpl;
+import hudson.slaves.NodeProperty;
+import hudson.slaves.NodeProvisioner;
+import hudson.util.FormValidation;
 import jenkins.model.Jenkins;
+import okhttp3.OkHttpClient;
+import okhttp3.Request;
+import org.kohsuke.stapler.DataBoundConstructor;
+import org.kohsuke.stapler.QueryParameter;
+import org.kohsuke.stapler.interceptor.RequirePOST;
+
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
@@ -83,7 +86,7 @@ public class NomadCloud extends AbstractCloudImpl {
         if (template != null) {
             try {
                 while (excessWorkload > 0) {
-                    
+
                     LOGGER.log(Level.INFO, "Excess workload of " + excessWorkload + ", provisioning new Jenkins slave on Nomad cluster");
 
                     final String slaveName = template.createSlaveName();
@@ -202,7 +205,9 @@ public class NomadCloud extends AbstractCloudImpl {
             return "Nomad";
         }
 
+        @RequirePOST
         public FormValidation doTestConnection(@QueryParameter("nomadUrl") String nomadUrl) {
+            Jenkins.getInstance().checkPermission(Jenkins.ADMINISTER);
             try {
                 Request request = new Request.Builder()
                         .url(nomadUrl + "/v1/agent/self")

--- a/src/main/java/org/jenkinsci/plugins/nomad/NomadCloud.java
+++ b/src/main/java/org/jenkinsci/plugins/nomad/NomadCloud.java
@@ -207,7 +207,7 @@ public class NomadCloud extends AbstractCloudImpl {
 
         @RequirePOST
         public FormValidation doTestConnection(@QueryParameter("nomadUrl") String nomadUrl) {
-            Jenkins.getInstance().checkPermission(Jenkins.ADMINISTER);
+            Objects.requireNonNull(Jenkins.getInstance()).checkPermission(Jenkins.ADMINISTER);
             try {
                 Request request = new Request.Builder()
                         .url(nomadUrl + "/v1/agent/self")

--- a/src/main/java/org/jenkinsci/plugins/nomad/NomadCloud.java
+++ b/src/main/java/org/jenkinsci/plugins/nomad/NomadCloud.java
@@ -17,14 +17,10 @@ import org.kohsuke.stapler.DataBoundConstructor;
 import org.kohsuke.stapler.QueryParameter;
 import org.kohsuke.stapler.interceptor.RequirePOST;
 
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.List;
+import java.util.*;
 import java.util.concurrent.*;
 import java.util.logging.Level;
 import java.util.logging.Logger;
-
 public class NomadCloud extends AbstractCloudImpl {
 
     private static final Logger LOGGER = Logger.getLogger(NomadCloud.class.getName());
@@ -222,7 +218,9 @@ public class NomadCloud extends AbstractCloudImpl {
             }
         }
 
+        @RequirePOST
         public FormValidation doCheckName(@QueryParameter String name) {
+            Objects.requireNonNull(Jenkins.getInstance()).checkPermission(Jenkins.ADMINISTER);
             if (Strings.isNullOrEmpty(name)) {
                 return FormValidation.error("Name must be set");
             } else {

--- a/src/main/java/org/jenkinsci/plugins/nomad/NomadCloud.java
+++ b/src/main/java/org/jenkinsci/plugins/nomad/NomadCloud.java
@@ -165,6 +165,7 @@ public class NomadCloud extends AbstractCloudImpl {
             ExecutorService executorService = Executors.newCachedThreadPool();
             Future<Boolean> future = executorService.submit(callableTask);
 
+            try{
                 future.get(cloud.workerTimeout, TimeUnit.MINUTES);
                 LOGGER.log(Level.INFO, "Connection established");
             } catch (Exception ex) {

--- a/src/main/java/org/jenkinsci/plugins/nomad/NomadConstraintTemplate.java
+++ b/src/main/java/org/jenkinsci/plugins/nomad/NomadConstraintTemplate.java
@@ -48,7 +48,7 @@ public class NomadConstraintTemplate implements Describable<NomadConstraintTempl
 	@Override
     @SuppressWarnings("unchecked")
     public Descriptor<NomadConstraintTemplate> getDescriptor() {
-        return Jenkins.getInstance().getDescriptor(getClass());
+        return Jenkins.get().getDescriptor(getClass());
     }
 
 	public String getLtarget() {

--- a/src/main/java/org/jenkinsci/plugins/nomad/NomadPortTemplate.java
+++ b/src/main/java/org/jenkinsci/plugins/nomad/NomadPortTemplate.java
@@ -27,7 +27,7 @@ public class NomadPortTemplate implements Describable<NomadPortTemplate> {
     @Override
     @SuppressWarnings("unchecked")
     public Descriptor<NomadPortTemplate> getDescriptor() {
-        return Jenkins.getInstance().getDescriptor(getClass());
+        return Jenkins.get().getDescriptor(getClass());
     }
 
     public String getLabel() {

--- a/src/main/java/org/jenkinsci/plugins/nomad/NomadProvisioningStrategy.java
+++ b/src/main/java/org/jenkinsci/plugins/nomad/NomadProvisioningStrategy.java
@@ -32,7 +32,7 @@ public class NomadProvisioningStrategy extends NodeProvisioner.Strategy {
     public NodeProvisioner.StrategyDecision apply(@Nonnull NodeProvisioner.StrategyState strategyState) {
         final Label label = strategyState.getLabel();
         LoadStatisticsSnapshot snapshot = strategyState.getSnapshot();
-        for ( Cloud nomadCloud : Jenkins.getActiveInstance().clouds ){
+        for ( Cloud nomadCloud : Jenkins.get().clouds ){
             if ( nomadCloud instanceof NomadCloud ) {
 
                 LOGGER.log(Level.FINE, "Available executors={0} connecting executors={1} AdditionalPlannedCapacity={2} pending ={3}",

--- a/src/main/java/org/jenkinsci/plugins/nomad/NomadSlave.java
+++ b/src/main/java/org/jenkinsci/plugins/nomad/NomadSlave.java
@@ -45,7 +45,7 @@ public class NomadSlave extends AbstractCloudSlave implements EphemeralNode {
             template.getNumExecutors(),
             template.getMode(),
             labelString,
-            new JNLPLauncher(),
+            new JNLPLauncher(false),
             retentionStrategy,
             nodeProperties
         );
@@ -100,11 +100,11 @@ public class NomadSlave extends AbstractCloudSlave implements EphemeralNode {
     @Override
     protected void _terminate(TaskListener listener)  {
         LOGGER.log(Level.INFO, "Asking Nomad to deregister slave '" + getNodeName() + "'");
-        getCloud().Nomad().stopSlave(getNodeName());
+        getCloud().Nomad().stopSlave(getNodeName(), getCloud().getNomadACL());
     }
 
     public NomadCloud getCloud() {
-        return (NomadCloud) Jenkins.getInstance().getCloud(cloudName);
+        return (NomadCloud) Jenkins.get().getCloud(cloudName);
     }
 
     public String getCloudName() {

--- a/src/main/java/org/jenkinsci/plugins/nomad/NomadSlaveTemplate.java
+++ b/src/main/java/org/jenkinsci/plugins/nomad/NomadSlaveTemplate.java
@@ -130,7 +130,7 @@ public class NomadSlaveTemplate implements Describable<NomadSlaveTemplate> {
     @Override
     @SuppressWarnings("unchecked")
     public Descriptor<NomadSlaveTemplate> getDescriptor() {
-        return Jenkins.getInstance().getDescriptor(getClass());
+        return Jenkins.get().getDescriptor(getClass());
     }
 
     public String createSlaveName() {
@@ -219,6 +219,14 @@ public class NomadSlaveTemplate implements Describable<NomadSlaveTemplate> {
 
     public String getDriver() {
         return driver;
+    }
+
+    public Boolean isDockerDriver(){
+        return getDriver().equals("docker");
+    }
+
+    public Boolean isJavaDriver(){
+        return getDriver().equals("java");
     }
 
     public Boolean getPrivileged() {

--- a/src/main/resources/org/jenkinsci/plugins/nomad/NomadCloud/config.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/nomad/NomadCloud/config.jelly
@@ -22,6 +22,10 @@
     <f:textbox default="1"/>
   </f:entry>
 
+  <f:entry title="Nomad ACL" field="nomadACL" description="Valid Nomad ACL Token">
+    <f:password />
+  </f:entry>
+
   <f:entry title="Jenkins Slave URL" field="slaveUrl" description="Jenkins slave URL">
     <f:textbox default="${instance.getSlaveUrl()}"/>
   </f:entry>

--- a/src/test/java/org/jenkinsci/plugins/nomad/NomadApiTest.java
+++ b/src/test/java/org/jenkinsci/plugins/nomad/NomadApiTest.java
@@ -32,6 +32,7 @@ public class NomadApiTest {
             "jenkinsTunnel",
             "slaveUrl",
             "1",
+            "",
             Collections.singletonList(slaveTemplate));
 
     @Before

--- a/src/test/java/org/jenkinsci/plugins/nomad/NomadCloudTest.java
+++ b/src/test/java/org/jenkinsci/plugins/nomad/NomadCloudTest.java
@@ -22,6 +22,7 @@ public class NomadCloudTest {
             "jenkinsTunnel",
             "slaveUrl",
             "1",
+            "",
             Collections.singletonList(slaveTemplate));
 
     @Before


### PR DESCRIPTION
Adds functionality to change the prefix used for the job name and an optional orphaned worker pruning process.

The Pruning process runs before scheduling new workers by asking Nomad for all jobs with the currently configured prefix. It then takes each job and looks up if Jenkins is aware of the worker or not. If jenkins doesn't know about the worker a stop command is issued to nomad for that Job.

The pruning is useful since the nomad jobs seem to stick around after a bounce of the master and currently require manual intervention to clean them up. The prefix is useful to enable us to shard our nomad giving each master it's own prefix allowing them to share a worker pool.