### PR TITLE
Don't always set the tunnel value.

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/nomad/NomadCloud.java
+++ b/src/main/java/org/jenkinsci/plugins/nomad/NomadCloud.java
@@ -84,10 +84,6 @@ public class NomadCloud extends AbstractCloudImpl {
             jenkinsUrl = Jenkins.get().getRootUrl();
         }
 
-        if (jenkinsTunnel.equals("")) {
-            jenkinsTunnel = jenkinsUrl;
-        }
-
         if (slaveUrl.equals("")) {
             slaveUrl = jenkinsUrl + "jnlpJars/slave.jar";
         }


### PR DESCRIPTION
If it's not set, there must be a good reason, and NomadApi.java takes
care of *not* passing the `-tunnel` option if it's empty.
---

I have a configuration where the *Jenkins Base URL* is set to `http://jenkins-master.my.hostname/jenkins/`, but the *Jenkins Tunnel* option is empty.
When starting a new worker, this produces the following log:

```
Jun 26, 2019 4:34:27 PM hudson.remoting.jnlp.Main createEngine
INFO: Setting up agent: jenkins-worker-builder-1f24946fc9a24
Jun 26, 2019 4:34:27 PM hudson.remoting.jnlp.Main$CuiListener <init>
INFO: Jenkins agent is running in headless mode.
Jun 26, 2019 4:34:27 PM hudson.remoting.Engine startEngine
INFO: Using Remoting version: 3.33
Jun 26, 2019 4:34:27 PM hudson.remoting.Engine startEngine
WARNING: No Working Directory. Using the legacy JAR Cache location: /workspace/.jenkins/cache/jars
Jun 26, 2019 4:34:28 PM hudson.remoting.jnlp.Main$CuiListener status
INFO: Locating server among [http://jenkins-master.my.hostname/jenkins/]
Jun 26, 2019 4:34:28 PM org.jenkinsci.remoting.engine.JnlpAgentEndpointResolver resolve
INFO: Remoting server accepts the following protocols: [JNLP4-connect, Ping]
Jun 26, 2019 4:34:28 PM org.jenkinsci.remoting.engine.JnlpAgentEndpointResolver resolve
INFO: Remoting TCP connection tunneling is enabled. Skipping the TCP Agent Listener Port availability check
Jun 26, 2019 4:34:28 PM hudson.remoting.jnlp.Main$CuiListener error
SEVERE: For input string: "//jenkins-master.my.hostname/jenkins/"
java.lang.NumberFormatException: For input string: "//jenkins-master.my.hostname/jenkins/"
	at java.base/java.lang.NumberFormatException.forInputString(NumberFormatException.java:65)
	at java.base/java.lang.Integer.parseInt(Integer.java:638)
	at java.base/java.lang.Integer.parseInt(Integer.java:770)
	at org.jenkinsci.remoting.engine.JnlpAgentEndpointResolver.resolve(JnlpAgentEndpointResolver.java:331)
	at hudson.remoting.Engine.innerRun(Engine.java:523)
	at hudson.remoting.Engine.run(Engine.java:474)
```

There's currently a [check to ensure the tunnel option is set only when actually configured](https://github.com/jenkinsci/nomad-plugin/blob/4240bfacd04f10530d4918444d4c980083f556aa/src/main/java/org/jenkinsci/plugins/nomad/NomadApi.java#L142) but the tunnel option [can never be empty](https://github.com/jenkinsci/nomad-plugin/blob/4240bfacd04f10530d4918444d4c980083f556aa/src/main/java/org/jenkinsci/plugins/nomad/NomadCloud.java#L87:L89) (and actually filled with a value it will *not* understand).

I haven't tested the fix.