### PR TITLE
Use jenkins credentials to store nomad token

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -79,7 +79,16 @@
       <artifactId>json</artifactId>
       <version>20180130</version>
     </dependency>
-
+    <dependency>
+        <groupId>org.jenkins-ci.plugins</groupId>
+        <artifactId>credentials</artifactId>
+        <version>2.1.16</version>
+    </dependency>
+    <dependency>
+        <groupId>org.jenkins-ci.plugins</groupId>
+        <artifactId>plain-credentials</artifactId>
+        <version>1.4</version>
+    </dependency>
     <!-- TESTS -->
     <dependency>
       <groupId>org.mockito</groupId>

--- a/src/main/resources/org/jenkinsci/plugins/nomad/NomadCloud/config.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/nomad/NomadCloud/config.jelly
@@ -1,6 +1,6 @@
 <?jelly escape-by-default='true'?>
 
-<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
+<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form" xmlns:c="/lib/credentials">
 
   <f:entry title="Name" field="name" description="A unique name for this Nomad cloud">
     <f:textbox checkMethod="post" />
@@ -12,7 +12,7 @@
 
   <f:entry title="Nomad URL" field="nomadUrl" description="Nomad API URL [hostname:port]">
     <f:textbox default="http://127.0.0.1:4646"/>
-  </f:entry>j
+  </f:entry>
 
   <f:entry title="Jenkins Base URL" field="jenkinsUrl" description="Jenkins base URL">
     <f:textbox default="${instance.getJenkinsUrl()}"/>
@@ -26,8 +26,8 @@
     <f:textbox default="1"/>
   </f:entry>
 
-  <f:entry title="Nomad ACL" field="nomadACL" description="Valid Nomad ACL Token">
-    <f:password />
+  <f:entry title="Nomad ACL" field="nomadACLCredentialsId" description="Valid Nomad ACL Token">
+    <c:select/>
   </f:entry>
 
   <f:entry title="Jenkins Slave URL" field="slaveUrl" description="Jenkins slave URL">


### PR DESCRIPTION
We use the jenkins secret text credential to store the nomad token.

!Breaking change: we cannot migrate existing secret nomad token to a
jenkins credential. User will have to manually create a new jenkins
credential as secret text and select it in the configuration.

heavily inspired on @i4s-pserrano work (see https://github.com/jenkinsci/nomad-plugin/pull/32/commits/2e7f9c7126a70efa9137127c3dab017fb4d0b0fb)