### PR TITLE
Add cap_add and extra_hosts to Nomad Docker option

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/nomad/NomadApi.java
+++ b/src/main/java/org/jenkinsci/plugins/nomad/NomadApi.java
@@ -184,6 +184,16 @@ public final class NomadApi {
             driverConfig.put("force_pull", template.getForcePull());
             driverConfig.put("privileged", template.getPrivileged());
             driverConfig.put("network_mode", template.getNetwork());
+
+            String extraHosts = template.getExtraHosts();
+            if (!extraHosts.isEmpty()) {
+                driverConfig.put("extra_hosts", StringUtils.split(extraHosts, ", "));
+            }
+
+            String capAdd = template.getCapAdd();
+            if (!capAdd.isEmpty()) {
+                driverConfig.put("cap_add", StringUtils.split(capAdd, ", "));
+            }
         }
 
         return driverConfig;

--- a/src/main/java/org/jenkinsci/plugins/nomad/NomadSlaveTemplate.java
+++ b/src/main/java/org/jenkinsci/plugins/nomad/NomadSlaveTemplate.java
@@ -43,6 +43,8 @@ public class NomadSlaveTemplate implements Describable<NomadSlaveTemplate> {
     private final String switchUser;
     private final Node.Mode mode;
     private final List<? extends NomadPortTemplate> ports;
+    private final String extraHosts;
+    private final String capAdd;
 
     private NomadCloud cloud;
     private String driver;
@@ -74,7 +76,9 @@ public class NomadSlaveTemplate implements Describable<NomadSlaveTemplate> {
             Boolean forcePull,
             String hostVolumes,
             String switchUser,
-            List<? extends NomadPortTemplate> ports
+            List<? extends NomadPortTemplate> ports,
+            String extraHosts,
+            String capAdd
     ) {
         if (StringUtils.isNotEmpty(prefix))
             this.prefix = prefix;
@@ -113,6 +117,8 @@ public class NomadSlaveTemplate implements Describable<NomadSlaveTemplate> {
         } else {
             this.ports = ports;
         }
+        this.extraHosts = extraHosts;
+        this.capAdd = capAdd;
         readResolve();
     }
 
@@ -265,5 +271,13 @@ public class NomadSlaveTemplate implements Describable<NomadSlaveTemplate> {
 
     public List<? extends NomadPortTemplate> getPorts() {
         return Collections.unmodifiableList(ports);
+    }
+
+    public String getCapAdd() {
+        return capAdd;
+    }
+
+    public String getExtraHosts() {
+        return extraHosts;
     }
 }

--- a/src/main/resources/org/jenkinsci/plugins/nomad/NomadSlaveTemplate/config.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/nomad/NomadSlaveTemplate/config.jelly
@@ -88,6 +88,12 @@
             <f:entry title="Switch User" field="switchUser">
                 <f:textbox name="switchUser" field="switchUser" default="" />
             </f:entry>
+            <f:entry title="Extra Hosts" field="extraHosts">
+                <f:textbox name="extraHosts" field="extraHosts" default="" />
+            </f:entry>
+            <f:entry title="Add Capabilities" field="capAdd">
+                <f:textbox name="capAdd" field="capAdd" default="" />
+            </f:entry>
         </f:optionalBlock>
 
         <f:entry title="Ports" help="/plugin/nomad/help-ports.html">

--- a/src/main/resources/org/jenkinsci/plugins/nomad/NomadSlaveTemplate/help-capAdd.html
+++ b/src/main/resources/org/jenkinsci/plugins/nomad/NomadSlaveTemplate/help-capAdd.html
@@ -1,0 +1,3 @@
+<div>
+    A comma delimited list of capabilities to pass directly to --cap-add.
+</div>

--- a/src/main/resources/org/jenkinsci/plugins/nomad/NomadSlaveTemplate/help-extraHosts.html
+++ b/src/main/resources/org/jenkinsci/plugins/nomad/NomadSlaveTemplate/help-extraHosts.html
@@ -1,0 +1,3 @@
+<div>
+    A comma delimited list of host:IP strings to be added to /etc/hosts.
+</div>

--- a/src/test/java/org/jenkinsci/plugins/nomad/NomadApiTest.java
+++ b/src/test/java/org/jenkinsci/plugins/nomad/NomadApiTest.java
@@ -21,8 +21,8 @@ public class NomadApiTest {
             "test", "300", "256", "100",
             null, constraintTest, "remoteFs", "3", true, "1", Node.Mode.NORMAL,
             "ams", "0", "image", "dc01", "", "", false, "bridge",
-            "", true, "/mnt:/mnt", "jenkins", new ArrayList<NomadPortTemplate>() {
-    }
+            "", true, "/mnt:/mnt", "jenkins", new ArrayList<NomadPortTemplate>() {},
+            "my_host:192.168.1.1,", "SYS_ADMIN, SYSLOG"
     );
 
     private NomadCloud nomadCloud = new NomadCloud(
@@ -55,6 +55,8 @@ public class NomadApiTest {
         assertTrue(job.contains("\"force_pull\":true"));
         assertTrue(job.contains("\"volumes\":[\"/mnt:/mnt\"]"));
         assertTrue(job.contains("\"User\":\"jenkins\""));
+        assertTrue(job.contains("\"extra_hosts\":[\"my_host:192.168.1.1\"]"));
+        assertTrue(job.contains("\"cap_add\":[\"SYS_ADMIN\",\"SYSLOG\"]"));
     }
 
 }


### PR DESCRIPTION
This allows the user to configure extra_hosts and cap_add to the
requested docker job.  The split takes either comma or space,
effectively trimming off any extra spaces.

This is a rebase of #36 from @jchuong