### PR TITLE
Apocol/nomad plugin

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/nomad/NomadApi.java
+++ b/src/main/java/org/jenkinsci/plugins/nomad/NomadApi.java
@@ -194,6 +194,11 @@ public final class NomadApi {
             if (!capAdd.isEmpty()) {
                 driverConfig.put("cap_add", StringUtils.split(capAdd, ", "));
             }
+
+            String capDrop = template.getCapDrop();
+            if (!capDrop.isEmpty()) {
+                driverConfig.put("cap_drop", StringUtils.split(capDrop, ", "));
+            }
         }
 
         return driverConfig;

--- a/src/main/java/org/jenkinsci/plugins/nomad/NomadSlaveTemplate.java
+++ b/src/main/java/org/jenkinsci/plugins/nomad/NomadSlaveTemplate.java
@@ -45,6 +45,8 @@ public class NomadSlaveTemplate implements Describable<NomadSlaveTemplate> {
     private final List<? extends NomadPortTemplate> ports;
     private final String extraHosts;
     private final String capAdd;
+    private final String capDrop;
+
 
     private NomadCloud cloud;
     private String driver;
@@ -78,7 +80,8 @@ public class NomadSlaveTemplate implements Describable<NomadSlaveTemplate> {
             String switchUser,
             List<? extends NomadPortTemplate> ports,
             String extraHosts,
-            String capAdd
+            String capAdd,
+            String capDrop
     ) {
         if (StringUtils.isNotEmpty(prefix))
             this.prefix = prefix;
@@ -119,6 +122,7 @@ public class NomadSlaveTemplate implements Describable<NomadSlaveTemplate> {
         }
         this.extraHosts = extraHosts;
         this.capAdd = capAdd;
+        this.capDrop = capDrop;
         readResolve();
     }
 
@@ -275,6 +279,10 @@ public class NomadSlaveTemplate implements Describable<NomadSlaveTemplate> {
 
     public String getCapAdd() {
         return capAdd;
+    }
+
+    public String getCapDrop() {
+        return capDrop;
     }
 
     public String getExtraHosts() {

--- a/src/main/resources/org/jenkinsci/plugins/nomad/NomadSlaveTemplate/config.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/nomad/NomadSlaveTemplate/config.jelly
@@ -94,6 +94,9 @@
             <f:entry title="Add Capabilities" field="capAdd">
                 <f:textbox name="capAdd" field="capAdd" default="" />
             </f:entry>
+            <f:entry title="Add Capabilities" field="capDrop">
+                <f:textbox name="capDrop" field="capDrop" default="" />
+            </f:entry>
         </f:optionalBlock>
 
         <f:entry title="Ports" help="/plugin/nomad/help-ports.html">

--- a/src/test/java/org/jenkinsci/plugins/nomad/NomadApiTest.java
+++ b/src/test/java/org/jenkinsci/plugins/nomad/NomadApiTest.java
@@ -22,7 +22,7 @@ public class NomadApiTest {
             null, constraintTest, "remoteFs", "3", true, "1", Node.Mode.NORMAL,
             "ams", "0", "image", "dc01", "", "", false, "bridge",
             "", true, "/mnt:/mnt", "jenkins", new ArrayList<NomadPortTemplate>() {},
-            "my_host:192.168.1.1,", "SYS_ADMIN, SYSLOG"
+            "my_host:192.168.1.1,", "SYS_ADMIN, SYSLOG", "SYS_ADMIN, SYSLOG"
     );
 
     private NomadCloud nomadCloud = new NomadCloud(
@@ -57,6 +57,7 @@ public class NomadApiTest {
         assertTrue(job.contains("\"User\":\"jenkins\""));
         assertTrue(job.contains("\"extra_hosts\":[\"my_host:192.168.1.1\"]"));
         assertTrue(job.contains("\"cap_add\":[\"SYS_ADMIN\",\"SYSLOG\"]"));
+        assertTrue(job.contains("\"cap_drop\":[\"SYS_ADMIN\",\"SYSLOG\"]"));
     }
 
 }


### PR DESCRIPTION
MR #52 gives users the option to add capabilities, but not to drop them - but the [nomad code](https://github.com/hashicorp/nomad) itself requires _both_ in order to deliver expected behaviour. 

If I want to add, say, `MKNOD` capabilities to my container, I need to add the capability using the Jenkins plugin and also [whitelist](https://www.nomadproject.io/docs/drivers/docker.html#plugin_caps) it in my `nomad-client.hcl`. That is the expected behaviour. But this will actually give me the following Docker driver error in my nomad agent:
```
Docker driver doesn't have the following caps whitelisted on this Nomad agent: [list of all basic capabilities minus MKNOD]
```
because _I haven't explicitly dropped all of the other basic Docker-defined capabilities_. The reason I need to drop them has to do with how the [`TweakCapabilities`](https://github.com/hashicorp/nomad/blob/master/vendor/github.com/moby/moby/daemon/caps/utils_unix.go#L84) function in the nomad code works. This function (which produces the final list of capabilities desired by the user, i.e. [`effectiveCaps`](https://github.com/hashicorp/nomad/blob/66674116dc361078725f0f52732741180c628b6f/drivers/docker/driver_default.go#L27)) defines tweaking as:

1. starting with the [basic Docker-defined capabilities](https://github.com/hashicorp/nomad/blob/master/drivers/docker/config.go#L40)
2. removing those explicitly dropped by the user
3. adding any additional capabilities explicitly added by the user

The code then takes the resulting list and validates against the user-defined whitelist.

Since this plugin currently doesn't let users drop capabilities, step 2 doesn't happen and the result of [`TweakCapabilities`](https://github.com/hashicorp/nomad/blob/master/vendor/github.com/moby/moby/daemon/caps/utils_unix.go#L84) is essentially just the entire [basic Docker-defined capability list](https://github.com/hashicorp/nomad/blob/master/drivers/docker/config.go#L40). But, of course, the user hasn't _whitelisted_ the entire basic capability list... They shouldn't have to! So the ensuing validation fails and the result is the aforementioned Docker driver error:

```
Docker driver doesn't have the following caps whitelisted on this Nomad agent: [list of all basic capabilities minus those whitelisted]
```

In my opinion, the nomad [`TweakCapabilities`](https://github.com/hashicorp/nomad/blob/master/vendor/github.com/moby/moby/daemon/caps/utils_unix.go#L84) function implementation is not completely intuitive (I would just do step 3 above and validate that against the basic list), but in lieu of changing that, the workaround I've come up with is to add this capability-dropping feature. 