### PR TITLE
Remove nested NomadCloud object

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/nomad/NomadCloud.java
+++ b/src/main/java/org/jenkinsci/plugins/nomad/NomadCloud.java
@@ -88,9 +88,6 @@ public class NomadCloud extends AbstractCloudImpl {
     }
 
     private Object readResolve() {
-        for (NomadSlaveTemplate template : this.templates) {
-            template.setCloud(this);
-        }
         nomad = new NomadApi(nomadUrl);
 
         if (jenkinsUrl.equals("")) {
@@ -183,7 +180,7 @@ public class NomadCloud extends AbstractCloudImpl {
             }
 
             LOGGER.log(Level.INFO, "Asking Nomad to schedule new Jenkins slave");
-            nomad.startSlave(slaveName, getNomadACL(), jnlpSecret, template);
+            nomad.startSlave(cloud, slaveName, getNomadACL(), jnlpSecret, template);
 
             // Check scheduling success
             Callable<Boolean> callableTask = () -> {

--- a/src/main/java/org/jenkinsci/plugins/nomad/NomadSlaveTemplate.java
+++ b/src/main/java/org/jenkinsci/plugins/nomad/NomadSlaveTemplate.java
@@ -48,7 +48,6 @@ public class NomadSlaveTemplate implements Describable<NomadSlaveTemplate> {
     private final String capDrop;
 
 
-    private NomadCloud cloud;
     private String driver;
     private String datacenters;
     private Set<LabelAtom> labelSet;
@@ -211,14 +210,6 @@ public class NomadSlaveTemplate implements Describable<NomadSlaveTemplate> {
 
     public int getDisk() {
         return disk;
-    }
-
-    public void setCloud(NomadCloud cloud) {
-        this.cloud = cloud;
-    }
-
-    public NomadCloud getCloud() {
-        return cloud;
     }
 
     public String getRemoteFs() {

--- a/src/test/java/org/jenkinsci/plugins/nomad/NomadApiTest.java
+++ b/src/test/java/org/jenkinsci/plugins/nomad/NomadApiTest.java
@@ -36,14 +36,9 @@ public class NomadApiTest {
             false,
             Collections.singletonList(slaveTemplate));
 
-    @Before
-    public void setup() {
-        slaveTemplate.setCloud(nomadCloud);
-    }
-
     @Test
     public void testStartSlave() {
-        String job = nomadApi.buildSlaveJob("slave-1", "secret", slaveTemplate);
+        String job = nomadApi.buildSlaveJob("slave-1", "secret", nomadCloud, slaveTemplate);
 
         assertTrue(job.contains("\"Region\":\"ams\""));
         assertTrue(job.contains("\"CPU\":300"));


### PR DESCRIPTION
This should improve the interaction with the export feature of the "Configuration as code" plugin, which currently falls into an infinite loop:

1. It starts to export a `NomadCloud` object.
2. It then start to export each of the `NomadSlaveTemplate` objects ...
3. Which in turn have a reference towards the `NomadCloud` object ...
4. Which starts to get exported and loops back to 1.

Fix: #54
Fix: [JENKINS-58491](https://issues.jenkins-ci.org/browse/JENKINS-58491)

@phedoreanu I replaced the embedded attribute by a new parameter injected where is needed. I'm not sure what's the "best" order for these arguments though, if you have a better idea on the topic, I'll gladly update that order.