### PR TITLE
Apocol/raw exec

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/nomad/NomadApi.java
+++ b/src/main/java/org/jenkinsci/plugins/nomad/NomadApi.java
@@ -132,6 +132,21 @@ public final class NomadApi {
 
             driverConfig.put("jar_path", "/local/slave.jar");
             driverConfig.put("args", args);
+        } else if (template.isRawExecDriver()) {
+            args.add("-jar");
+            args.add("./local/slave.jar");
+
+            args.add("-jnlpUrl");
+            args.add(Util.ensureEndsWith(cloud.getJenkinsUrl(), "/") + "computer/" + name + "/slave-agent.jnlp");
+
+            // java -cp /local/slave.jar [options...] <secret key> <agent name>
+            if (!secret.isEmpty()) {
+                args.add("-secret");
+                args.add(secret);
+            }
+
+            driverConfig.put("command", "java");
+            driverConfig.put("args", args);
         } else if (template.isDockerDriver()) {
             args.add("-headless");
 

--- a/src/main/java/org/jenkinsci/plugins/nomad/NomadSlaveTemplate.java
+++ b/src/main/java/org/jenkinsci/plugins/nomad/NomadSlaveTemplate.java
@@ -32,6 +32,7 @@ public class NomadSlaveTemplate implements Describable<NomadSlaveTemplate> {
     private final List<? extends NomadConstraintTemplate> constraints;
     private final String region;
     private final String remoteFs;
+    private final Boolean useRawExec;
     private final String image;
     private final Boolean privileged;
     private final String network;
@@ -61,6 +62,7 @@ public class NomadSlaveTemplate implements Describable<NomadSlaveTemplate> {
             String labels,
             List<? extends NomadConstraintTemplate> constraints,
             String remoteFs,
+            Boolean useRawExec,
             String idleTerminationInMinutes,
             Boolean reusable,
             String numExecutors,
@@ -96,6 +98,7 @@ public class NomadSlaveTemplate implements Describable<NomadSlaveTemplate> {
         this.numExecutors = Integer.parseInt(numExecutors);
         this.mode = mode;
         this.remoteFs = remoteFs;
+        this.useRawExec = useRawExec;
         this.labels = Util.fixNull(labels);
         if (constraints == null) {
             this.constraints = Collections.emptyList();
@@ -111,9 +114,9 @@ public class NomadSlaveTemplate implements Describable<NomadSlaveTemplate> {
         this.privileged = privileged;
         this.network = network;
         this.prefixCmd = prefixCmd;
+        this.switchUser = switchUser;
         this.forcePull = forcePull;
         this.hostVolumes = hostVolumes;
-        this.switchUser = switchUser;
         if (ports == null) {
             this.ports = Collections.emptyList();
         } else {
@@ -127,6 +130,7 @@ public class NomadSlaveTemplate implements Describable<NomadSlaveTemplate> {
 
     protected Object readResolve() {
         this.driver = !this.image.equals("") ? "docker" : "java";
+        if (this.useRawExec) this.driver = "raw_exec";
         return this;
     }
 
@@ -216,6 +220,10 @@ public class NomadSlaveTemplate implements Describable<NomadSlaveTemplate> {
         return remoteFs;
     }
 
+    public Boolean useRawExec() {
+        return useRawExec;
+    }
+
     public String getImage() {
         return image;
     }
@@ -232,6 +240,10 @@ public class NomadSlaveTemplate implements Describable<NomadSlaveTemplate> {
         return prefixCmd;
     }
 
+    public String getSwitchUser() {
+        return switchUser;
+    }
+
     public String getDriver() {
         return driver;
     }
@@ -242,6 +254,10 @@ public class NomadSlaveTemplate implements Describable<NomadSlaveTemplate> {
 
     public Boolean isJavaDriver(){
         return getDriver().equals("java");
+    }
+
+    public Boolean isRawExecDriver(){
+        return getDriver().equals("raw_exec");
     }
 
     public Boolean getPrivileged() {
@@ -258,10 +274,6 @@ public class NomadSlaveTemplate implements Describable<NomadSlaveTemplate> {
 
     public String getHostVolumes() {
         return hostVolumes;
-    }
-
-    public String getSwitchUser() {
-        return switchUser;
     }
 
     public List<? extends NomadPortTemplate> getPorts() {

--- a/src/main/resources/org/jenkinsci/plugins/nomad/NomadSlaveTemplate/config.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/nomad/NomadSlaveTemplate/config.jelly
@@ -64,7 +64,7 @@
             <f:textbox/>
         </f:entry>
 
-        <f:entry title="Disable filesystem isolation (use raw_exec driver)" field="useRawExec">
+        <f:entry title="Use raw_exec driver" field="useRawExec">
             <f:checkbox name="useRawExec" field="useRawExec" default="false" value="${instance.useRawExec}" />
         </f:entry>
 

--- a/src/main/resources/org/jenkinsci/plugins/nomad/NomadSlaveTemplate/config.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/nomad/NomadSlaveTemplate/config.jelly
@@ -38,6 +38,10 @@
             <f:textbox default="dc1"/>
         </f:entry>
 
+        <f:entry title="Switch User" field="switchUser">
+            <f:textbox name="switchUser" default="" />
+        </f:entry>
+
         <f:entry title="Priority" field="priority">
             <f:textbox/>
         </f:entry>
@@ -58,6 +62,10 @@
 
         <f:entry title="Workspace root" field="remoteFs">
             <f:textbox/>
+        </f:entry>
+
+        <f:entry title="Disable filesystem isolation (use raw_exec driver)" field="useRawExec">
+            <f:checkbox name="useRawExec" field="useRawExec" default="false" value="${instance.useRawExec}" />
         </f:entry>
 
         <f:optionalBlock name="docker" title="Use Docker driver" inline="true" checked="${!instance.image.isEmpty()}">
@@ -84,9 +92,6 @@
             </f:entry>
             <f:entry title="Prefix Command" field="preCmd">
                 <f:textbox name="prefixCmd" field="prefixCmd"/>
-            </f:entry>
-            <f:entry title="Switch User" field="switchUser">
-                <f:textbox name="switchUser" field="switchUser" default="" />
             </f:entry>
             <f:entry title="Extra Hosts" field="extraHosts">
                 <f:textbox name="extraHosts" field="extraHosts" default="" />

--- a/src/test/java/org/jenkinsci/plugins/nomad/NomadApiTest.java
+++ b/src/test/java/org/jenkinsci/plugins/nomad/NomadApiTest.java
@@ -19,7 +19,7 @@ public class NomadApiTest {
     private List<NomadConstraintTemplate> constraintTest = new ArrayList<NomadConstraintTemplate>();
     private NomadSlaveTemplate slaveTemplate = new NomadSlaveTemplate(
             "test", "300", "256", "100",
-            null, constraintTest, "remoteFs", "3", true, "1", Node.Mode.NORMAL,
+            null, constraintTest, "remoteFs", false, "3", true, "1", Node.Mode.NORMAL,
             "ams", "0", "image", "dc01", "", "", false, "bridge",
             "", true, "/mnt:/mnt", "jenkins", new ArrayList<NomadPortTemplate>() {},
             "my_host:192.168.1.1,", "SYS_ADMIN, SYSLOG", "SYS_ADMIN, SYSLOG"


### PR DESCRIPTION
My changes to the plugin allow for the use of Nomad's raw_exec driver, as well as the ability to switch the user with both the Java and raw_exec drivers (whereas this is currently only possible with the Docker driver). Combined, these changes satisfy a use case that I believe is reasonable and important. 

I would like to use Hashicorp Packer to build Docker images, and Hashicorp Nomad to allocate these Packer builds - with Jenkins orchestrating all of this via the Nomad plugin. 

But the plugin makes this difficult, for two main reasons: users and chroot jails. 

Firstly, whatever user the Nomad agent runs as [needs to be in the Docker group](https://docs.docker.com/install/linux/linux-postinstall/). But the default Java driver user is [`nobody`](https://www.nomadproject.io/docs/job-specification/task.html#user), and adding the `nobody` user to the Docker group is undesirable. Further, the plugin doesn't currently let me switch to, say, the `jenkins` user when using the Java driver.

Secondly, the Java driver places the agent in a [chroot jail](https://www.nomadproject.io/docs/drivers/java.html#resource-isolation). But I want to use the system `/var/run/docker.sock`, not a copied or hardlinked one - and even if the latter sufficed, the socket doesn't get copied into the chroot jail even when I add its path to the `chroot_env` section in the Nomad config file (which is a [known issue](https://github.com/hashicorp/nomad/issues/5351#issue-413070218)). So the Nomad agent using the Java driver fails to run Docker via Packer: 
```
Cannot connect to the Docker daemon at unix:///var/run/docker.sock. Is the docker daemon running?
```


NOTE: I have set it up such that if you select both the Docker and raw_exec drivers, the raw_exec driver is used (but the logic can easily be reversed [`here`](https://github.com/AndreeaPocol/nomad-plugin/blob/apocol/raw_exec/src/main/java/org/jenkinsci/plugins/nomad/NomadSlaveTemplate.java#L131)). Really, though, such configuration is asking for undefined behaviour. 