### PR TITLE
Apocol/fix UI entry titles

### DIFF
--- a/src/main/resources/org/jenkinsci/plugins/nomad/NomadConstraintTemplate/config.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/nomad/NomadConstraintTemplate/config.jelly
@@ -4,7 +4,7 @@
 
 	<table width="100%">
 
-		<f:entry title="LTarget" field="ltarget">
+		<f:entry title="Attribute" field="ltarget">
             <f:textbox/>
         </f:entry>
 
@@ -12,7 +12,7 @@
             <f:textbox/>
         </f:entry>
 
-        <f:entry title="RTarget" field="rtarget">
+        <f:entry title="Value" field="rtarget">
             <f:textbox/>
         </f:entry>
     

--- a/src/main/resources/org/jenkinsci/plugins/nomad/NomadSlaveTemplate/config.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/nomad/NomadSlaveTemplate/config.jelly
@@ -94,7 +94,7 @@
             <f:entry title="Add Capabilities" field="capAdd">
                 <f:textbox name="capAdd" field="capAdd" default="" />
             </f:entry>
-            <f:entry title="Add Capabilities" field="capDrop">
+            <f:entry title="Drop Capabilities" field="capDrop">
                 <f:textbox name="capDrop" field="capDrop" default="" />
             </f:entry>
         </f:optionalBlock>


### PR DESCRIPTION
Fixed constraint parameters to be more intuitive and correspond with the Nomad [docs](https://www.nomadproject.io/docs/job-specification/constraint.html#constraint-parameters), as well as a typo in the entry title for `capDrop`. 