### PR TITLE
Add Docker's security_opt parameter

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/nomad/NomadApi.java
+++ b/src/main/java/org/jenkinsci/plugins/nomad/NomadApi.java
@@ -206,6 +206,11 @@ public final class NomadApi {
                 driverConfig.put("extra_hosts", StringUtils.split(extraHosts, ", "));
             }
 
+            String securityOpt = template.getSecurityOpt();
+            if (securityOpt != null && !securityOpt.isEmpty()) {
+                driverConfig.put("security_opt", StringUtils.split(securityOpt, ", "));
+            }
+            
             String capAdd = template.getCapAdd();
             if (capAdd != null && !capAdd.isEmpty()) {
                 driverConfig.put("cap_add", StringUtils.split(capAdd, ", "));
@@ -270,7 +275,7 @@ public final class NomadApi {
                 new TaskGroup[]{taskGroup}
         );
 
-        Gson gson = new Gson();
+        Gson gson = new GsonBuilder().disableHtmlEscaping().create();
         JsonObject jobJson = new JsonObject();
 
         jobJson.add("Job", gson.toJsonTree(job));

--- a/src/main/java/org/jenkinsci/plugins/nomad/NomadSlaveTemplate.java
+++ b/src/main/java/org/jenkinsci/plugins/nomad/NomadSlaveTemplate.java
@@ -45,6 +45,7 @@ public class NomadSlaveTemplate implements Describable<NomadSlaveTemplate> {
     private final Node.Mode mode;
     private final List<? extends NomadPortTemplate> ports;
     private final String extraHosts;
+    private final String securityOpt;
     private final String capAdd;
     private final String capDrop;
 
@@ -81,6 +82,7 @@ public class NomadSlaveTemplate implements Describable<NomadSlaveTemplate> {
             String switchUser,
             List<? extends NomadPortTemplate> ports,
             String extraHosts,
+            String securityOpt,
             String capAdd,
             String capDrop
     ) {
@@ -123,6 +125,7 @@ public class NomadSlaveTemplate implements Describable<NomadSlaveTemplate> {
             this.ports = ports;
         }
         this.extraHosts = extraHosts;
+        this.securityOpt = securityOpt;
         this.capAdd = capAdd;
         this.capDrop = capDrop;
         readResolve();
@@ -278,6 +281,10 @@ public class NomadSlaveTemplate implements Describable<NomadSlaveTemplate> {
 
     public List<? extends NomadPortTemplate> getPorts() {
         return Collections.unmodifiableList(ports);
+    }
+
+    public String getSecurityOpt() {
+        return securityOpt;
     }
 
     public String getCapAdd() {

--- a/src/main/resources/org/jenkinsci/plugins/nomad/NomadSlaveTemplate/config.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/nomad/NomadSlaveTemplate/config.jelly
@@ -96,6 +96,9 @@
             <f:entry title="Extra Hosts" field="extraHosts">
                 <f:textbox name="extraHosts" field="extraHosts" default="" />
             </f:entry>
+            <f:entry title="Add Security Options" field="securityOpt">
+                <f:textbox name="securityOpt" field="securityOpt" default="" />
+            </f:entry>
             <f:entry title="Add Capabilities" field="capAdd">
                 <f:textbox name="capAdd" field="capAdd" default="" />
             </f:entry>

--- a/src/main/resources/org/jenkinsci/plugins/nomad/NomadSlaveTemplate/help-securityOpt.html
+++ b/src/main/resources/org/jenkinsci/plugins/nomad/NomadSlaveTemplate/help-securityOpt.html
@@ -1,0 +1,3 @@
+<div>
+  A comma delimited list of security options to pass directly to --security_opt.
+</div>

--- a/src/test/java/org/jenkinsci/plugins/nomad/NomadApiTest.java
+++ b/src/test/java/org/jenkinsci/plugins/nomad/NomadApiTest.java
@@ -22,7 +22,7 @@ public class NomadApiTest {
             null, constraintTest, "remoteFs", false, "3", true, "1", Node.Mode.NORMAL,
             "ams", "0", "image", "dc01", "", "", false, "bridge",
             "", true, "/mnt:/mnt", "jenkins", new ArrayList<NomadPortTemplate>() {},
-            "my_host:192.168.1.1,", "SYS_ADMIN, SYSLOG", "SYS_ADMIN, SYSLOG"
+            "my_host:192.168.1.1,","apparmor=unconfined, seccomp=unconfined","SYS_ADMIN, SYSLOG", "SYS_ADMIN, SYSLOG"
     );
 
     private NomadCloud nomadCloud = new NomadCloud(
@@ -51,8 +51,8 @@ public class NomadApiTest {
         assertTrue(job.contains("\"volumes\":[\"/mnt:/mnt\"]"));
         assertTrue(job.contains("\"User\":\"jenkins\""));
         assertTrue(job.contains("\"extra_hosts\":[\"my_host:192.168.1.1\"]"));
+        assertTrue(job.contains("\"security_opt\":[\"apparmor=unconfined\",\"seccomp=unconfined\"]"));
         assertTrue(job.contains("\"cap_add\":[\"SYS_ADMIN\",\"SYSLOG\"]"));
         assertTrue(job.contains("\"cap_drop\":[\"SYS_ADMIN\",\"SYSLOG\"]"));
     }
-
 }


### PR DESCRIPTION
This PR allows the user to set security_opt's whithin nomads task driver definition for docker.
See https://www.nomadproject.io/docs/drivers/docker/#security_opt.