### PR TITLE
Upgrade configuration UI from tables to div

### DIFF
--- a/src/main/resources/org/jenkinsci/plugins/nomad/NomadConstraintTemplate/config.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/nomad/NomadConstraintTemplate/config.jelly
@@ -2,7 +2,7 @@
 
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
 
-	<table width="100%">
+	<div>
 
 		<f:entry title="Attribute" field="ltarget">
             <f:textbox/>
@@ -15,11 +15,11 @@
         <f:entry title="Value" field="rtarget">
             <f:textbox/>
         </f:entry>
-    
+
         <f:entry>
             <f:repeatableDeleteButton />
         </f:entry>
 
-    </table>
+    </div>
 
 </j:jelly>

--- a/src/main/resources/org/jenkinsci/plugins/nomad/NomadDevicePluginsTemplate/config.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/nomad/NomadDevicePluginsTemplate/config.jelly
@@ -2,7 +2,7 @@
 
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
 
-	<table width="100%">
+	<div>
 
 		<f:entry title="Name" field="name">
             <f:textbox/>
@@ -11,11 +11,11 @@
         <f:entry title="Count" field="count">
             <f:textbox/>
         </f:entry>
-    
+
         <f:entry>
             <f:repeatableDeleteButton />
         </f:entry>
 
-    </table>
+    </div>
 
 </j:jelly>

--- a/src/main/resources/org/jenkinsci/plugins/nomad/NomadPortTemplate/config.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/nomad/NomadPortTemplate/config.jelly
@@ -2,7 +2,7 @@
 
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
 
-	<table width="100%">
+	<div>
 
 		<f:entry title="Label" field="label">
             <f:textbox/>
@@ -16,6 +16,6 @@
             <f:repeatableDeleteButton />
         </f:entry>
 
-    </table>
+    </div>
 
 </j:jelly>

--- a/src/main/resources/org/jenkinsci/plugins/nomad/NomadWorker/configure-entries.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/nomad/NomadWorker/configure-entries.jelly
@@ -1,7 +1,7 @@
 <?jelly escape-by-default='true'?>
 
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
-    <table width="100%">
+    <div>
         <f:entry title="${%Cloud Name}" field="cloudName">
           <f:readOnlyTextbox />
         </f:entry>
@@ -27,5 +27,5 @@
         <f:entry title="Reusable">
             <f:checkbox name="reusable" field="reusable" default="true" value="${instance.reusable}" />
         </f:entry>
-    </table>
+    </div>
 </j:jelly>

--- a/src/main/resources/org/jenkinsci/plugins/nomad/NomadWorkerTemplate/config.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/nomad/NomadWorkerTemplate/config.jelly
@@ -2,7 +2,7 @@
 
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
 
-    <table width="100%">
+    <div>
 
         <f:entry title="Job Prefix" field="prefix">
             <f:textbox default="jenkins"/>
@@ -40,7 +40,7 @@
 
         <f:entry title="Vault Policies" field="vaultPolicies">
             <f:textbox/>
-        </f:entry>        
+        </f:entry>
 
         <f:entry title="Switch User" field="switchUser">
             <f:textbox name="switchUser" default="" />
@@ -132,6 +132,6 @@
             </div>
         </f:entry>
 
-    </table>
+    </div>
 
 </j:jelly>


### PR DESCRIPTION
On recent versions of Jenkins, it's not possible to save the
configuration of this plugin in the "Configure Cloud" page.
It also impacts any other "Cloud" plugin which is configured there, and
render the whole "Configure Cloud" page unusable anymore, as long as the
nomad-plugin is configured.

Fix: [JENKINS-64488](https://issues.jenkins.io/browse/JENKINS-64488)