### PR TITLE
fix that the secret is not set when global security is disabled

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/nomad/NomadCloud.java
+++ b/src/main/java/org/jenkinsci/plugins/nomad/NomadCloud.java
@@ -15,7 +15,7 @@ import hudson.slaves.NodeProvisioner;
 import hudson.util.FormValidation;
 import hudson.util.ListBoxModel;
 import jenkins.model.Jenkins;
-import jenkins.slaves.JnlpSlaveAgentProtocol;
+import jenkins.slaves.JnlpAgentReceiver;
 import okhttp3.OkHttpClient;
 import okhttp3.Request;
 import okhttp3.ResponseBody;
@@ -398,11 +398,7 @@ public class NomadCloud extends AbstractCloudImpl {
             );
             Jenkins.get().addNode(worker);
 
-            // Support for Jenkins security
-            String jnlpSecret = "";
-            if (Jenkins.get().isUseSecurity()) {
-                jnlpSecret = JnlpSlaveAgentProtocol.SLAVE_SECRET.mac(workerName);
-            }
+            String jnlpSecret = JnlpAgentReceiver.SLAVE_SECRET.mac(workerName);
 
             LOGGER.log(Level.INFO, "Asking Nomad to schedule new Jenkins worker");
             nomad.startWorker(cloud, workerName, getNomadACL(), jnlpSecret, template);


### PR DESCRIPTION
Fix that Agents in unsecured Jenkins environments can be started.

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

How to reproduce?
* start Jenkins with global security disabled (Configure Global Security -> Security Realm -> None)
* install and setup the plugin as usual
* create and start a job which starts an agent in Nomad
* expected: agent is started
* actual: agent is not started because the secret is empty