### PR TITLE
feat: Add maximum jobs per template configuration

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -35,7 +35,7 @@
     <properties>
         <revision>0.10.1</revision>
         <changelist>-SNAPSHOT</changelist>
-        <jenkins.version>2.375</jenkins.version>
+        <jenkins.version>2.407</jenkins.version>
         <json-path-assert.version>2.8.0</json-path-assert.version>
     </properties>
 

--- a/src/main/java/org/jenkinsci/plugins/nomad/NomadWorkerTemplate.java
+++ b/src/main/java/org/jenkinsci/plugins/nomad/NomadWorkerTemplate.java
@@ -29,6 +29,7 @@ public class NomadWorkerTemplate implements Describable<NomadWorkerTemplate> {
 
     // persistent fields
     private final String prefix;
+    private final int maxConcurrentJobs;
     private final int idleTerminationInMinutes;
     private final boolean reusable;
     private final int numExecutors;
@@ -98,6 +99,7 @@ public class NomadWorkerTemplate implements Describable<NomadWorkerTemplate> {
     public NomadWorkerTemplate(
             String prefix,
             String labels,
+            int maxConcurrentJobs,
             int idleTerminationInMinutes,
             boolean reusable,
             int numExecutors,
@@ -105,6 +107,7 @@ public class NomadWorkerTemplate implements Describable<NomadWorkerTemplate> {
             String jobTemplate
     ) {
         this.prefix = prefix.isEmpty() ? SLAVE_PREFIX : prefix;
+        this.maxConcurrentJobs = maxConcurrentJobs;
         this.idleTerminationInMinutes = idleTerminationInMinutes;
         this.reusable = reusable;
         this.numExecutors = numExecutors;
@@ -125,6 +128,10 @@ public class NomadWorkerTemplate implements Describable<NomadWorkerTemplate> {
 
     public String getPrefix() {
         return prefix;
+    }
+
+    public int getMaxConcurrentJobs() {
+        return maxConcurrentJobs;
     }
 
     public int getIdleTerminationInMinutes() {
@@ -201,6 +208,7 @@ public class NomadWorkerTemplate implements Describable<NomadWorkerTemplate> {
             NomadWorkerTemplate template = new NomadWorkerTemplate(
                     "validate-template",
                     null,
+                    -1,
                     0,
                     false,
                     1,

--- a/src/main/resources/org/jenkinsci/plugins/nomad/NomadWorkerTemplate/config.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/nomad/NomadWorkerTemplate/config.jelly
@@ -12,6 +12,10 @@
             <f:textbox />
         </f:entry>
 
+        <f:entry title="Maximum Number of concurrent Job (-1 for unmimited)" field="maxConcurrentJobs">
+            <f:number default="-1" />
+        </f:entry>
+
         <f:entry title="Idle termination time" field="idleTerminationInMinutes">
             <f:number default="10" />
         </f:entry>

--- a/src/test/java/org/jenkinsci/plugins/nomad/NomadCloudTest.java
+++ b/src/test/java/org/jenkinsci/plugins/nomad/NomadCloudTest.java
@@ -122,6 +122,7 @@ public class NomadCloudTest {
         return new NomadWorkerTemplate(
                 "jenkins",
                 labels,
+                -1,
                 1,
                 true,
                 1,


### PR DESCRIPTION
**Description:**
This pull request adds the feature to configure the maximum number of concurrent jobs per template in the Nomad plugin. It allows users to set a limit on the number of jobs that can be provisioned using a specific template.
This can be usefull in case of you nomad pool is shared across differents jenkins AND you do not have the chance to be able to use the premium quota feature.. :)

**Changes:**

- Added a new parameter, `maxConcurrentJobs`, to the `NomadWorkerTemplate` class.
- Modified the `NomadCloud` class to include a check for the maximum number of jobs when provisioning new Jenkins workers.
- Introduced a new method, `checkExcessJobs()`, in the `NomadCloud` class to determine if the maximum configured jobs for a template have been reached during provisioning.
- Updated the Jenkins configuration UI (`config.jelly`) for the `NomadWorkerTemplate` to include the new `maxConcurrentJobs` field.
- Update existing unit tests in `NomadCloudTest` to do not break

I consider that the parameter with the value -1 is unlimited.
In my test, upgrade to the plugin have one issue. Each existing template will the value "0" until the user change it. Is there a way that I could set it to -1 so the default value would be unlimited so it doesn't break existing users configurations ? Thanks for your recommandations and reviews !