### PR TITLE
Use OnceRetentionStrategy for single-use agents

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/nomad/NomadOnceRetentionStrategy.java
+++ b/src/main/java/org/jenkinsci/plugins/nomad/NomadOnceRetentionStrategy.java
@@ -1,0 +1,34 @@
+package org.jenkinsci.plugins.nomad;
+
+import hudson.slaves.AbstractCloudComputer;
+import hudson.slaves.CloudRetentionStrategy;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+public class NomadOnceRetentionStrategy extends CloudRetentionStrategy {
+    private static final Logger LOGGER = Logger.getLogger(NomadOnceRetentionStrategy.class.getName());
+
+    public NomadOnceRetentionStrategy(int idleMinutes) {
+        super(idleMinutes);
+    }
+
+    @Override
+    public long check(AbstractCloudComputer c) {
+        // If the node is idle AND it has already executed a build, kill it immediately.
+        if (c.isIdle() && !c.getBuilds().isEmpty()) {
+            LOGGER.log(Level.INFO, "Single-use Nomad node {0} finished its build. Terminating immediately.", c.getName());
+            try {
+                if (c.getNode() != null) {
+                    c.getNode().terminate();
+                }
+            } catch (Exception e) {
+                LOGGER.log(Level.WARNING, "Failed to terminate Nomad node", e);
+            }
+            return 1;
+        }
+        
+        // Otherwise, it's either still running a job, OR it's a brand new node booting up.
+        // Let the standard idle timeout handle the boot grace period.
+        return super.check(c);
+    }
+}

--- a/src/main/java/org/jenkinsci/plugins/nomad/NomadOnceRetentionStrategy.java
+++ b/src/main/java/org/jenkinsci/plugins/nomad/NomadOnceRetentionStrategy.java
@@ -1,6 +1,7 @@
 package org.jenkinsci.plugins.nomad;
 
 import hudson.slaves.AbstractCloudComputer;
+import hudson.slaves.AbstractCloudSlave;
 import hudson.slaves.CloudRetentionStrategy;
 import java.util.logging.Level;
 import java.util.logging.Logger;
@@ -18,8 +19,9 @@ public class NomadOnceRetentionStrategy extends CloudRetentionStrategy {
         if (c.isIdle() && !c.getBuilds().isEmpty()) {
             LOGGER.log(Level.INFO, "Single-use Nomad node {0} finished its build. Terminating immediately.", c.getName());
             try {
-                if (c.getNode() != null) {
-                    c.getNode().terminate();
+                AbstractCloudSlave node = (AbstractCloudSlave) c.getNode();
+                if (node != null) {
+                    node.terminate();
                 }
             } catch (Exception e) {
                 LOGGER.log(Level.WARNING, "Failed to terminate Nomad node", e);

--- a/src/main/java/org/jenkinsci/plugins/nomad/NomadOnceRetentionStrategy.java
+++ b/src/main/java/org/jenkinsci/plugins/nomad/NomadOnceRetentionStrategy.java
@@ -1,13 +1,19 @@
 package org.jenkinsci.plugins.nomad;
 
+import hudson.model.Computer;
+import hudson.model.Executor;
+import hudson.model.ExecutorListener;
+import hudson.model.OneOffExecutor;
+import hudson.model.Queue;
 import hudson.slaves.AbstractCloudComputer;
 import hudson.slaves.AbstractCloudSlave;
 import hudson.slaves.CloudRetentionStrategy;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
-public class NomadOnceRetentionStrategy extends CloudRetentionStrategy {
+public class NomadOnceRetentionStrategy extends CloudRetentionStrategy implements ExecutorListener {
     private static final Logger LOGGER = Logger.getLogger(NomadOnceRetentionStrategy.class.getName());
+    private transient boolean terminating;
 
     public NomadOnceRetentionStrategy(int idleMinutes) {
         super(idleMinutes);
@@ -15,9 +21,57 @@ public class NomadOnceRetentionStrategy extends CloudRetentionStrategy {
 
     @Override
     public long check(AbstractCloudComputer c) {
-        // If the node is idle AND it has already executed a build, kill it immediately.
+        // Fallback: If the node is idle AND it has already executed a build, kill it.
         if (c.isIdle() && !c.getBuilds().isEmpty()) {
-            LOGGER.log(Level.INFO, "Single-use Nomad node {0} finished its build. Terminating immediately.", c.getName());
+            LOGGER.log(Level.INFO, "Fallback: Single-use Nomad node {0} finished its build. Terminating.", c.getName());
+            terminate(c);
+            return 1;
+        }
+
+        // Otherwise, it's either still running a job, OR it's a brand new node booting up.
+        // Let the standard idle timeout handle the boot grace period.
+        return super.check(c);
+    }
+
+    @Override
+    public void taskAccepted(Executor executor, Queue.Task task) {
+        // Do nothing when task starts
+    }
+
+    @Override
+    public void taskCompleted(Executor executor, Queue.Task task, long durationMS) {
+        done(executor);
+    }
+
+    @Override
+    public void taskCompletedWithProblems(Executor executor, Queue.Task task, long durationMS, Throwable problems) {
+        done(executor);
+    }
+
+    private void done(Executor executor) {
+        final AbstractCloudComputer<?> c = (AbstractCloudComputer<?>) executor.getOwner();
+
+        // Ignore flyweight tasks (lightweight background tasks that don't use real executors)
+        if (executor instanceof OneOffExecutor) {
+            return;
+        }
+
+        LOGGER.log(Level.INFO, "Event: Task completed on single-use node {0}. Terminating immediately.", c.getName());
+        terminate(c);
+    }
+
+    private void terminate(final AbstractCloudComputer<?> c) {
+        c.setAcceptingTasks(false); // Stop Jenkins from sending new jobs here
+
+        synchronized (this) {
+            if (terminating) {
+                return;
+            }
+            terminating = true;
+        }
+
+        // Run termination in a background thread to prevent locking up the Jenkins executor
+        Computer.threadPoolForRemoting.submit(() -> {
             try {
                 AbstractCloudSlave node = (AbstractCloudSlave) c.getNode();
                 if (node != null) {
@@ -25,12 +79,10 @@ public class NomadOnceRetentionStrategy extends CloudRetentionStrategy {
                 }
             } catch (Exception e) {
                 LOGGER.log(Level.WARNING, "Failed to terminate Nomad node", e);
+                synchronized (NomadOnceRetentionStrategy.this) {
+                    terminating = false; // Reset so the fallback check() can try again later
+                }
             }
-            return 1;
-        }
-        
-        // Otherwise, it's either still running a job, OR it's a brand new node booting up.
-        // Let the standard idle timeout handle the boot grace period.
-        return super.check(c);
+        });
     }
 }

--- a/src/main/java/org/jenkinsci/plugins/nomad/NomadWorker.java
+++ b/src/main/java/org/jenkinsci/plugins/nomad/NomadWorker.java
@@ -33,7 +33,11 @@ public class NomadWorker extends AbstractCloudSlave implements EphemeralNode {
         setLabelString(labelString);
         setMode(labelString.isEmpty() ? Mode.NORMAL : Mode.EXCLUSIVE);
         setNumExecutors(numExecutors);
-        setRetentionStrategy(new NomadRetentionStrategy(idleTerminationInMinutes));
+        if (reusable) {
+            setRetentionStrategy(new NomadRetentionStrategy(idleTerminationInMinutes));
+        } else {
+            setRetentionStrategy(new NomadOnceRetentionStrategy(idleTerminationInMinutes));
+        }
 
         this.cloudName = cloudName;
         this.reusable = reusable;

--- a/src/test/java/org/jenkinsci/plugins/nomad/NomadWorkerTest.java
+++ b/src/test/java/org/jenkinsci/plugins/nomad/NomadWorkerTest.java
@@ -1,0 +1,24 @@
+package org.jenkinsci.plugins.nomad;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.jvnet.hudson.test.JenkinsRule;
+import static org.junit.Assert.assertTrue;
+
+public class NomadWorkerTest {
+
+    @Rule
+    public JenkinsRule j = new JenkinsRule();
+
+    @Test
+    public void testRetentionStrategyReusable() throws Exception {
+        NomadWorker worker = new NomadWorker("name", "cloudName", "label", 1, 10, true, "/tmp");
+        assertTrue(worker.getRetentionStrategy() instanceof NomadRetentionStrategy);
+    }
+
+    @Test
+    public void testRetentionStrategyOnce() throws Exception {
+        NomadWorker worker = new NomadWorker("name", "cloudName", "label", 1, 10, false, "/tmp");
+        assertTrue(worker.getRetentionStrategy() instanceof NomadOnceRetentionStrategy);
+    }
+}


### PR DESCRIPTION
<!-- Please describe your pull request here. -->

### Use OnceRetentionStrategy for single-use Nomad agents

The current hardcoded CloudRetentionStrategy only checks a worker's total idle time. When `idleTerminationInMinutes` is configured to `0`, this creates a race condition that frequently terminates booting containers before they can connect. Conversely, setting it to `> 0` leaves zombie containers running idly after their build has finished.

This PR introduces a custom `NomadOnceRetentionStrategy` for single-use (non-reusable) Nomad workers. This strategy natively solves both problems by granting a generous timeout during initial boot (respecting the `idleTerminationInMinutes`), but instantly terminating the worker the millisecond its build is complete.

Rather than importing `OnceRetentionStrategy` from the `durable-task` plugin, this PR implements a custom version. The `durable-task` version explicitly forbids nodes from implementing `EphemeralNode`. Because existing Jenkins environments have saved their `NomadCloud` workers as `EphemeralNode` objects, removing the interface causes Jenkins to crash on boot due to XStream serialization failures. Writing our own custom strategy allows us to safely fix the zombie container issue while maintaining backward compatibility with existing saved Jenkins configurations.

### Testing done

* Automated Tests: Added `NomadWorkerTest.java` to verify the correct retention strategy is applied based on the "Reusable" flag. Verified that the existing test suite continues to pass (`mvn test`) without compilation errors or regressions.
* Manual Testing:
  1. Built the `.hpi` artifact locally and installed it on a live Jenkins server.
  2. Configured a Nomad cloud with a Worker Template where "Reusable" is unchecked and "Idle termination time" is set to 5.
  3. Triggered a job. Verified that the container booted successfully, the container was immediately terminated upon job completion without leaving a zombie slot behind.

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Submitter checklist
- [ x ] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [ x ] Ensure that the pull request title represents the desired changelog entry
- [ x ] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ x ] Ensure you have provided tests that demonstrate the feature works or the issue is fixed

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
